### PR TITLE
Add an "r" option for pire_inline as a shortcut for Fsm::Reverse

### DIFF
--- a/pire/inline.lpp
+++ b/pire/inline.lpp
@@ -133,6 +133,7 @@ void eatComment(void (*action)(char));
 		Pire::Lexer lexer(i->c_str(), i->c_str() + i->size());
 		bool surround = false;
 		bool greedy = false;
+		bool reverse = false;
 		for (const char* option = (i+1)->c_str(); *option; ++option) {
 			if (*option == 'i')
 				lexer.AddFeature(Pire::Features::CaseInsensitive());
@@ -144,6 +145,8 @@ void eatComment(void (*action)(char));
 				lexer.AddFeature(Pire::Features::AndNotSupport());
 			else if (*option == 'g')
 				greedy = true;
+			else if (*option == 'r')
+				reverse = true;
 			else
 				Die() << "unknown option " <<  *option << "";
 		}
@@ -155,6 +158,8 @@ void eatComment(void (*action)(char));
 		catch (std::exception& e) {
 			Die() << "" << filename << ":" <<  line << ": " <<  e.what() << "";
 		}
+		if (reverse)
+			fsm.Reverse();
 		if (greedy && surround)
 			Die() << "greedy and surround options are incompatible";
 		if (greedy)


### PR DESCRIPTION
Add an "r" option for pire_inline as a shortcut for Fsm::Reverse
