### PR TITLE
Fix build (with newer autotools?)

### DIFF
--- a/pire/Makefile.am
+++ b/pire/Makefile.am
@@ -77,7 +77,7 @@ pire_hdr_HEADERS = \
 	partition.h \
 	pire.h \
 	re_lexer.h \
-	re_parser.h \
+	re_parser.hpp \
 	run.h \
 	static_assert.h \
 	platform.h \
@@ -116,8 +116,8 @@ bin_PROGRAMS = pire_inline
 pire_inline_SOURCES = inline.lpp stub/hacks.h stub/memstreams.h
 pire_inline_LDADD = libpire.la
 
-BUILT_SOURCES = re_parser.h re_parser.cpp
-CLEANFILES    = re_parser.h re_parser.cpp
+BUILT_SOURCES = re_parser.hpp re_parser.cpp
+CLEANFILES    = re_parser.hpp re_parser.cpp
 
 AM_YFLAGS = -d
 

--- a/pire/re_lexer.cpp
+++ b/pire/re_lexer.cpp
@@ -25,7 +25,7 @@
 #include "stub/utf8.h"
 #include "stub/singleton.h"
 #include <stdexcept>
-#include "re_parser.h"
+#include "re_parser.hpp"
 #include "re_lexer.h"
 #include "fsm.h"
 #include "stub/stl.h"


### PR DESCRIPTION
On FreeBSD-9.1, with automake-1.14 autoconf-2.69, in generated pire/Makefile:in:

```
...
pire_hdr_HEADERS = \
        align.h \
        any.h \
        defs.h \
        determine.h \
        easy.h \
        encoding.h \
        extra.h \
        fsm.h \
        fwd.h \
        glue.h \
        partition.h \
        pire.h \
        re_lexer.h \
        re_parser.h \
        run.h \
        static_assert.h \
        platform.h \
        vbitset.h
...
BUILT_SOURCES = re_parser.h re_parser.cpp
CLEANFILES = re_parser.h re_parser.cpp
...
re_parser.hpp: re_parser.cpp
        @if test ! -f $@; then rm -f re_parser.cpp; else :; fi
        @if test ! -f $@; then $(MAKE) $(AM_MAKEFLAGS) re_parser.cpp; else :; fi
...
```

e.g. a rule for generating re_parser.hpp is generated, but re_parser.h is expected.

To keep header file naming uniform, either
- all headers should be renamed to .hpp as well
- maybe all sources may be renamed to .cc instead of this patch (haven't tested, just a wild guess)
- there may be a way to tell autotools explicitly that .h should be generated
