### PR TITLE
scanners have methods Translate and NextTranslated

### DIFF
--- a/pire/extra/capture.h
+++ b/pire/extra/capture.h
@@ -95,9 +95,23 @@ public:
 			s.m_end = s.m_counter - 1;
 	}
 
+	Char Translate(Char ch) const
+	{
+		return m_letters[static_cast<size_t>(ch)];
+	}
+
+	Action NextTranslated(State& s, unsigned char c) const
+	{
+		Transition x = reinterpret_cast<const Transition*>(s.m_state)[c];
+		s.m_state += SignExtend(x.shift);
+		++s.m_counter;
+
+		return x.action;
+	}
+
 	Action Next(State& s, Char c) const
 	{
-		return NextTranslated(s, m_letters[c]);
+		return NextTranslated(s, Translate(c));
 	}
 
 	Action Next(const State& current, State& n, Char c) const
@@ -133,15 +147,6 @@ public:
 
 private:
 
-	Action NextTranslated(State& s, unsigned char c) const
-	{
-		Transition x = reinterpret_cast<const Transition*>(s.m_state)[c];
-		s.m_state += SignExtend(x.shift);
-		++s.m_counter;
-
-		return x.action;
-	}
-			
 	friend void BuildScanner<CapturingScanner>(const Fsm&, CapturingScanner&);
 };
 namespace Features {

--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -97,9 +97,21 @@ public:
 
 	bool CanStop(const State&) const { return false; }
 
+	Char Translate(Char ch) const
+	{
+		return m_letters[static_cast<size_t>(ch)];
+	}
+
+	Action NextTranslated(State& s, Char c) const
+	{
+		Transition x = reinterpret_cast<const Transition*>(s.m_state)[c];
+		s.m_state += SignExtend(x.shift);
+		return x.action;
+	}
+
 	Action Next(State& s, Char c) const
 	{
-		return NextTranslated(s, m_letters[c]);
+		return NextTranslated(s, Translate(c));
 	}
 
 	Action Next(const State& current, State& n, Char c) const
@@ -158,17 +170,9 @@ private:
 		}
 	}
 
-	Action NextTranslated(State& s, Char c) const
-	{
-		Transition x = reinterpret_cast<const Transition*>(s.m_state)[c];
-		s.m_state += SignExtend(x.shift);
-
-		return x.action;
-	}
-
 	void Next(InternalState& s, Char c) const
 	{
-		Transition x = reinterpret_cast<const Transition*>(s)[m_letters[c]];
+		Transition x = reinterpret_cast<const Transition*>(s)[Translate(c)];
 		s += SignExtend(x.shift);
 	}
 

--- a/pire/scanners/multi.h
+++ b/pire/scanners/multi.h
@@ -155,8 +155,13 @@ public:
 	/// Returns an initial state for this scanner
 	void Initialize(State& state) const { state = m.initial; }
 
-	/// Handles one characters
-	Action Next(State& state, Char c) const
+	Char Translate(Char ch) const
+	{
+		return m_letters[static_cast<size_t>(ch)];
+	}
+
+	/// Handles one letter
+	Action NextTranslated(State& state, Char letter) const
 	{
 		PIRE_IFDEBUG(
 			YASSERT(state >= (size_t)m_transitions);
@@ -164,7 +169,7 @@ public:
 			YASSERT((state - (size_t)m_transitions) % (RowSize()*sizeof(Transition)) == 0);
 		);
 
-		state = Relocation::Go(state, reinterpret_cast<const Transition*>(state)[m_letters[c]]);
+		state = Relocation::Go(state, reinterpret_cast<const Transition*>(state)[letter]);
 
 		PIRE_IFDEBUG(
 			YASSERT(state >= (size_t)m_transitions);
@@ -173,6 +178,12 @@ public:
 		);
 
 		return 0;
+	}
+
+	/// Handles one character
+	Action Next(State& state, Char c) const
+	{
+		return NextTranslated(state, Translate(c));
 	}
 
 	void TakeAction(State&, Action) const {}

--- a/pire/scanners/slow.h
+++ b/pire/scanners/slow.h
@@ -87,9 +87,13 @@ public:
 		BitSet(m.statesCount).Swap(state.flags);
 	}
 
-	Action Next(const State& current, State& next, Char c) const
+	Char Translate(Char ch) const
 	{
-		size_t l = m_letters[c];
+		return m_letters[static_cast<size_t>(ch)];
+	}
+
+	Action NextTranslated(const State& current, State& next, Char l) const
+	{
 		next.flags.Clear();
 		next.states.clear();
 		for (yvector<unsigned>::const_iterator sit = current.states.begin(), sie = current.states.end(); sit != sie; ++sit) {
@@ -117,14 +121,24 @@ public:
 		return 0;
 	}
 
+	Action Next(const State& current, State& next, Char c) const
+	{
+		return NextTranslated(current, next, Translate(c));
+	}
+
 	bool TakeAction(State&, Action) const { return false; }
+
+	Action NextTranslated(State& s, Char l) const
+	{
+		State dest(m.statesCount);
+		Action a = NextTranslated(s, dest, l);
+		s.Swap(dest);
+		return a;
+	}
 
 	Action Next(State& s, Char c) const
 	{
-		State dest(m.statesCount);
-		Action a = Next(s, dest, c);
-		s.Swap(dest);
-		return a;
+		return NextTranslated(s, Translate(c));
 	}
 
 	bool Final(const State& s) const


### PR DESCRIPTION
In many scanners (all except SimpleScanner) method Next has two steps:

  * translate a character to a letter class through table m_letters
  * do something with a letter class (e.g., use it as an index in
    a transitions table)

These two steps were separated. Translating to letter classes
can be used outside of Next, e.g. to optimize this process.
New public method NextTranslated is a version of method Next, which
accepts a letter class instaed of a character. In some scanners
this method was present in private section.