### PR TITLE
publish some methods of CapturingScanner, CountingScanner and SlowScanner

### DIFF
--- a/pire/extra/capture.h
+++ b/pire/extra/capture.h
@@ -141,9 +141,7 @@ public:
 	void Swap(CapturingScanner& s) { LoadedScanner::Swap(s); }
 	CapturingScanner& operator = (const CapturingScanner& s) { CapturingScanner(s).Swap(*this); return *this; }
 
-#ifdef PIRE_DEBUG
 	size_t StateIndex(const State& s) const { return StateIdx(s.m_state); }
-#endif
 
 private:
 

--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -131,9 +131,7 @@ public:
 	void Swap(CountingScanner& s) { LoadedScanner::Swap(s); }
 	CountingScanner& operator = (const CountingScanner& s) { CountingScanner(s).Swap(*this); return *this; }
 
-#ifdef PIRE_DEBUG
 	size_t StateIndex(const State& s) const { return StateIdx(s.m_state); }
-#endif
 
 private:
 	using LoadedScanner::Init;

--- a/pire/scanners/loaded.h
+++ b/pire/scanners/loaded.h
@@ -107,6 +107,8 @@ public:
 
 	size_t RegexpsCount() const { return Empty() ? 0 : m.regexpsCount; }
 
+	size_t LettersCount() const { return m.lettersCount; }
+
 	const void* Mmap(const void* ptr, size_t size)
 	{
 		Impl::CheckAlign(ptr);
@@ -179,6 +181,16 @@ public:
 
 	i64 SignExtend(i32 i) const { return i; }
 
+	size_t BufSize() const
+	{
+		return
+			MaxChar * sizeof(*m_letters)
+			+ m.lettersCount * m.statesCount * sizeof(*m_jumps)
+			+ m.statesCount * sizeof(*m_tags)
+			+ m.lettersCount * m.statesCount * sizeof(*m_actions)
+			;
+	}
+
 protected:
 
 	static const size_t MAX_RE_COUNT      = 16;
@@ -203,16 +215,6 @@ protected:
 	Tag* m_tags;
 
 	virtual ~LoadedScanner();
-
-	size_t BufSize() const
-	{
-		return
-			MaxChar * sizeof(*m_letters)
-			+ m.lettersCount * m.statesCount * sizeof(*m_jumps)
-			+ m.statesCount * sizeof(*m_tags)
-			+ m.lettersCount * m.statesCount * sizeof(*m_actions)
-			;
-	}
 
 private:
 	explicit LoadedScanner(Fsm& fsm)

--- a/pire/scanners/slow.h
+++ b/pire/scanners/slow.h
@@ -270,9 +270,7 @@ public:
 	void Save(yostream*) const;
 	void Load(yistream*);
 
-#ifdef PIRE_DEBUG
 	const State& StateIndex(const State& s) const { return s; }
-#endif
 
 private:
 


### PR DESCRIPTION
Unify interface of scanners:

  * add CapturingScanner::StateIndex()
    It was enabled in debug mode only.
  * move LoadedScanner::BufSize() to public section.
  * add LoadedScanner::LettersCount()
  * publish method StateIndex of CountingScanner
  * publish method StateIndex of SlowScanner