### PR TITLE
add symlink debian -> pkg/debian

### DIFF
--- a/debian
+++ b/debian
@@ -1,0 +1,1 @@
+pkg/debian/


### PR DESCRIPTION
This is needed to build Debian package using `dpkg-buildpackage` or `debuild`.