### PR TITLE
fix possible warning in multi.h

### DIFF
--- a/pire/scanners/multi.h
+++ b/pire/scanners/multi.h
@@ -390,6 +390,7 @@ private:
 		m_buffer = 0;
 		m_letters = s.m_letters;
 		m_final = s.m_final;
+		m_finalEnd = s.m_finalEnd;
 		m_finalIndex = s.m_finalIndex;
 		m_transitions = s.m_transitions;
 	}


### PR DESCRIPTION
Fix the following warning:

```
'*((void*)& s +72)' may be used uninitialized in this function
/multi.h:243:11: note: '*((void*)& s +72)' was declared here
Scanner s;
```