### PR TITLE
ABI backward compatibility with RE_VERSION 6

### DIFF
--- a/pire/scanner_io.cpp
+++ b/pire/scanner_io.cpp
@@ -166,8 +166,8 @@ void LoadedScanner::Load(yistream* s)
 	Impl::AlignedLoadArray(s, sc.m_letters, MaxChar);
 	Impl::AlignedLoadArray(s, sc.m_jumps, sc.m.statesCount * sc.m.lettersCount);
 	if (header.Version == Header::RE_VERSION_WITH_MACTIONS) {
-		Action* actions = 0;
-		Impl::AlignedLoadArray(s, actions, sc.m.statesCount * sc.m.lettersCount);
+		yauto_ptr<Action> actions(new Action[sc.m.statesCount * sc.m.lettersCount]);
+		Impl::AlignedLoadArray(s, actions.get(), sc.m.statesCount * sc.m.lettersCount);
 	}
 	Impl::AlignedLoadArray(s, sc.m_tags, sc.m.statesCount);
 	sc.m.initial += reinterpret_cast<size_t>(sc.m_jumps);

--- a/pire/scanner_io.cpp
+++ b/pire/scanner_io.cpp
@@ -158,13 +158,17 @@ void LoadedScanner::Save(yostream* s) const
 void LoadedScanner::Load(yistream* s)
 {
 	LoadedScanner sc;
-	Impl::ValidateHeader(s, 4, sizeof(sc.m));
+	Header header = Impl::ValidateHeader(s, 4, sizeof(sc.m));
 	LoadPodType(s, sc.m);
 	Impl::AlignLoad(s, sizeof(sc.m));
 	sc.m_buffer = new char[sc.BufSize()];
 	sc.Markup(sc.m_buffer);
 	Impl::AlignedLoadArray(s, sc.m_letters, MaxChar);
 	Impl::AlignedLoadArray(s, sc.m_jumps, sc.m.statesCount * sc.m.lettersCount);
+	if (header.Version == Header::RE_VERSION_WITH_MACTIONS) {
+		Action* actions = 0;
+		Impl::AlignedLoadArray(s, actions, sc.m.statesCount * sc.m.lettersCount);
+	}
 	Impl::AlignedLoadArray(s, sc.m_tags, sc.m.statesCount);
 	sc.m.initial += reinterpret_cast<size_t>(sc.m_jumps);
 	Swap(sc);

--- a/pire/scanners/common.h
+++ b/pire/scanners/common.h
@@ -41,6 +41,7 @@ namespace Pire {
 
 		static const ui32 MAGIC = 0x45524950;   // "PIRE" on litte-endian
 		static const ui32 RE_VERSION = 7;       // Should be incremented each time when the format of serialized scanner changes
+		static const ui32 RE_VERSION_WITH_MACTIONS = 6;  // LoadedScanner with m_actions, which is ignored
 
 		explicit Header(ui32 type, size_t hdrsize)
 			: Magic(MAGIC)
@@ -55,7 +56,7 @@ namespace Pire {
 		{
 			if (Magic != MAGIC || PtrSize != sizeof(void*) || MaxWordSize != sizeof(Impl::MaxSizeWord))
 				throw Error("Serialized regexp incompatible with your system");
-			if (Version != RE_VERSION)
+			if (Version != RE_VERSION && Version != RE_VERSION_WITH_MACTIONS)
 				throw Error("You are trying to used an incompatible version of a serialized regexp");
 			if ((type != 0 && type != Type) || (hdrsize != 0 && HdrSize != hdrsize))
 				throw Error("Serialized regexp incompatible with your system");
@@ -86,19 +87,21 @@ namespace Pire {
 				throw Error("Tried to mmap scanner at misaligned address");
 		}
 
-		inline void ValidateHeader(const size_t*& ptr, size_t& size, ui32 type, size_t hdrsize)
+		inline Header ValidateHeader(const size_t*& ptr, size_t& size, ui32 type, size_t hdrsize)
 		{
 			const Header* hdr;
 			MapPtr(hdr, 1, ptr, size);
 			hdr->Validate(type, hdrsize);
+			return *hdr;
 		}
 
-		inline void ValidateHeader(yistream* s, ui32 type, size_t hdrsize)
+		inline Header ValidateHeader(yistream* s, ui32 type, size_t hdrsize)
 		{
 			Header hdr(0, 0);
 			LoadPodType(s, hdr);
 			AlignLoad(s, sizeof(hdr));
 			hdr.Validate(type, hdrsize);
+			return hdr;
 		}
 	}
 }

--- a/pire/scanners/loaded.h
+++ b/pire/scanners/loaded.h
@@ -113,7 +113,7 @@ public:
 		Impl::CheckAlign(ptr);
 		LoadedScanner s;
 		const size_t* p = reinterpret_cast<const size_t*>(ptr);
-		Impl::ValidateHeader(p, size, 4, sizeof(s.m));
+		Header header = Impl::ValidateHeader(p, size, 4, sizeof(s.m));
 
 		Locals* locals;
 		Impl::MapPtr(locals, 1, p, size);
@@ -121,6 +121,10 @@ public:
 		
 		Impl::MapPtr(s.m_letters, MaxChar, p, size);
 		Impl::MapPtr(s.m_jumps, s.m.statesCount * s.m.lettersCount, p, size);
+		if (header.Version == Header::RE_VERSION_WITH_MACTIONS) {
+			Action* actions = 0;
+			Impl::MapPtr(actions, s.m.statesCount * s.m.lettersCount, p, size);
+		}
 		Impl::MapPtr(s.m_tags, s.m.statesCount, p, size);
 		
 		s.m.initial += reinterpret_cast<size_t>(s.m_jumps);


### PR DESCRIPTION
Fix reading scanners serialized with previous PIRE version (RE_VERSION 6).