### PR TITLE
CountingScanner: increase RE count from 4 to 16

### DIFF
--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -38,7 +38,7 @@ namespace Impl {
 };
 
 template<size_t I>
-class PerformIncrementer {
+class IncrementPerformer {
 public:
 	template<typename State, typename Action>
 	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
@@ -47,7 +47,7 @@ public:
 		if (mask & (1 << (I - 1))) {
 			Increment(s);
 		}
-		PerformIncrementer<I - 1>::Do(s, mask);
+		IncrementPerformer<I - 1>::Do(s, mask);
 	}
 
 private:
@@ -60,7 +60,7 @@ private:
 };
 
 template<>
-class PerformIncrementer<0> {
+class IncrementPerformer<0> {
 public:
 	template<typename State, typename Action>
 	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
@@ -70,7 +70,7 @@ public:
 };
 
 template<size_t I>
-class PerformReseter {
+class ResetPerformer {
 public:
 	template<typename State, typename Action>
 	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
@@ -79,7 +79,7 @@ public:
 		if (mask & (1 << (LoadedScanner::MAX_RE_COUNT + (I - 1))) && s.m_current[I - 1]) {
 			Reset(s);
 		}
-		PerformReseter<I - 1>::Do(s, mask);
+		ResetPerformer<I - 1>::Do(s, mask);
 	}
 
 private:
@@ -93,7 +93,7 @@ private:
 };
 
 template<>
-class PerformReseter<0> {
+class ResetPerformer<0> {
 public:
 	template<typename State, typename Action>
 	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
@@ -132,10 +132,10 @@ public:
 		friend class CountingScanner;
 
 		template<size_t I>
-		friend class PerformIncrementer;
+		friend class IncrementPerformer;
 
 		template<size_t I>
-		friend class PerformReseter;
+		friend class ResetPerformer;
 
 #ifdef PIRE_DEBUG
 		friend yostream& operator << (yostream& s, const State& state)
@@ -219,7 +219,7 @@ private:
 	void PerformIncrement(State& s, Action mask) const
 	{
 		if (mask) {
-			PerformIncrementer<ActualReCount>::Do(s, mask);
+			IncrementPerformer<ActualReCount>::Do(s, mask);
 			s.m_updatedMask |= ((size_t)mask) << MAX_RE_COUNT;
 		}
 	}
@@ -229,7 +229,7 @@ private:
 	{
 		mask &= s.m_updatedMask;
 		if (mask) {
-			PerformReseter<ActualReCount>::Do(s, mask);
+			ResetPerformer<ActualReCount>::Do(s, mask);
 			s.m_updatedMask &= (Action)~mask;
 		}
 	}

--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -45,9 +45,17 @@ public:
 	static void Do(State& s, Action mask)
 	{
 		if (mask & (1 << (I - 1))) {
-			++s.m_current[I - 1];
+			Increment(s);
 		}
 		PerformIncrementer<I - 1>::Do(s, mask);
+	}
+
+private:
+	template<typename State>
+	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+	static void Increment(State& s)
+	{
+		++s.m_current[I - 1];
 	}
 };
 
@@ -69,10 +77,18 @@ public:
 	static void Do(State& s, Action mask)
 	{
 		if (mask & (1 << (LoadedScanner::MAX_RE_COUNT + (I - 1))) && s.m_current[I - 1]) {
-			s.m_total[I - 1] = ymax(s.m_total[I - 1], s.m_current[I - 1]);
-			s.m_current[I - 1] = 0;
+			Reset(s);
 		}
 		PerformReseter<I - 1>::Do(s, mask);
+	}
+
+private:
+	template<typename State>
+	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+	static void Reset(State& s)
+	{
+		s.m_total[I - 1] = ymax(s.m_total[I - 1], s.m_current[I - 1]);
+		s.m_current[I - 1] = 0;
 	}
 };
 

--- a/pire/scanners/loaded.h
+++ b/pire/scanners/loaded.h
@@ -70,6 +70,8 @@ public:
 		DeadFlag  = 0
 	};
 
+	static const size_t MAX_RE_COUNT = 16;
+
 protected:
 	LoadedScanner() { Alias(Null()); }
 
@@ -198,10 +200,8 @@ public:
 
 protected:
 
-	static const size_t MAX_RE_COUNT      = 16;
-
-	static const Action IncrementMask     = 0x0f;
-	static const Action ResetMask         = 0x0f << MAX_RE_COUNT;
+	static const Action IncrementMask     = (1 << MAX_RE_COUNT) - 1;
+	static const Action ResetMask         = IncrementMask << MAX_RE_COUNT;
 
 	// TODO: maybe, put fields in private section and provide data accessors
 


### PR DESCRIPTION
  * Update `IncrementMask` and `ResetMask` (16 bits instead of 4).
  * Make `LoadedScanner::MAX_RE_COUNT` public.
  * Increase number of counters in `State` from 4 to 16.
  * Implement incrementing and resetting with recursive template to avoid repeats of code.
  * Provide template method `TakeActionImpl<ActualReCount>` which is called with `ActualReCount = 16` by users who want 16 REs.
  * Method `TakeAction` calls `TakeActionImpl<4>`, so nothing changes for users of previous version of CountingScanner.

This change is API and ABI backward-compatible.