### PR TITLE
DoRun: fix possible invalid read (second attempt)

### DIFF
--- a/pire/run.h
+++ b/pire/run.h
@@ -105,6 +105,26 @@ namespace Impl {
 
 namespace Impl {
 
+	template<class Scanner, class Pred>
+	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+	Action SafeRunChunk(const Scanner& scanner, typename Scanner::State& state, const size_t* p, size_t pos, size_t size, Pred pred)
+	{
+		YASSERT(pos <= sizeof(size_t));
+		YASSERT(size <= sizeof(size_t));
+		YASSERT(pos + size <= sizeof(size_t));
+
+        if (PIRE_UNLIKELY(size == 0))
+            return Continue;
+
+		const char* ptr = (const char*) p + pos;
+		for (; size--; ++ptr) {
+			Step(scanner, state, (unsigned char) *ptr);
+			if (pred(scanner, state, ptr + 1) == Stop)
+				return Stop;
+		}
+		return Continue;
+	}
+
 	/// Effectively runs a scanner on a short data chunk, fit completely into one machine word.
 	template<class Scanner, class Pred>
 	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
@@ -114,17 +134,9 @@ namespace Impl {
 		YASSERT(size <= sizeof(size_t));
 		YASSERT(pos + size <= sizeof(size_t));
 
-        if (PIRE_UNLIKELY(size == 0))
-            return Continue;
+		if (PIRE_UNLIKELY(size == 0))
+			return Continue;
 
-#ifdef PIRE_ENABLE_VALGRIND_SAFE
-		const char* ptr = (const char*) p + pos;
-		for (; size--; ++ptr) {
-			Step(scanner, state, (unsigned char) *ptr);
-			if (pred(scanner, state, ptr + 1) == Stop)
-				return Stop;
-		}
-#else
 		size_t chunk = Impl::ToLittleEndian(*p) >> 8*pos;
 		const char* ptr = (const char*) p + pos + size + 1;
 
@@ -134,7 +146,6 @@ namespace Impl {
 				return Stop;
 			chunk >>= 8;
 		}
-#endif
 
 		return Continue;
 	}
@@ -188,7 +199,7 @@ namespace Impl {
 		YASSERT(tailSize < sizeof(void*));
 
 		if (head == tail) {
-			Impl::RunChunk(scanner, st, head, sizeof(void*) - headSize, end - begin, pred);
+			Impl::SafeRunChunk(scanner, st, head, sizeof(void*) - headSize, end - begin, pred);
 			return;
 		}
 
@@ -211,7 +222,7 @@ namespace Impl {
 		}
 
 		if (tailSize)
-			Impl::RunChunk(scanner, state, tail, 0, tailSize, pred);
+			Impl::SafeRunChunk(scanner, state, tail, 0, tailSize, pred);
 
 		st = state;
 	}


### PR DESCRIPTION
Following on from #22, ...

If a string passed to DoRun is less than `sizeof(size_t)`, then its content
can't be read as if its type is `size_t*`. DoRun splits the string to 3
parts: pre-aligned, algned and post-aligned. If there is no aligned part
of a string, then whole string is treated as pre- and post-aligned.

The error was caused by casting pre- and post-aligned parts to `size_t*`.
Now they are processed by code operating on `char*` (function SafeRunChunk).
(Actually pre-aligned part is allowed to be casted to `size_t*`, if aligned
part exists, ie. length of the string > size(size_t).)