### PR TITLE
lexer: fix Parse() memleaks on invalid regexps

### DIFF
--- a/pire/re_lexer.h
+++ b/pire/re_lexer.h
@@ -146,6 +146,9 @@ public:
 
 	const Pire::Encoding& Encoding() const { return *m_encoding; }
 	Lexer& SetEncoding(const Pire::Encoding& encoding) { m_encoding = &encoding; return *this; }
+	void SetError(const char* msg) { errmsg = msg; }
+	void SetError(ystring msg) { errmsg = msg; }
+	ystring& GetError() { return errmsg; }
 
 	Any& Retval() { return m_retval; }
 
@@ -168,6 +171,7 @@ private:
 	const Pire::Encoding* m_encoding;
 	yvector<Feature*> m_features;
 	Any m_retval;
+	ystring errmsg;
 
 	friend class Feature;
 


### PR DESCRIPTION
Parse() uses bison to parse regexps strings.
bison clears its own state stack before exiting from yyparse().
But bison don't support C++ exceptions so its state remains
uncleared if an exception is thrown from its yylex() or yyerror()
callbacks.

So, we have to delay a Pire::Error exception & re-throw it just after
exiting from yyparse().

Delaying exceptions other than Pire::Error is out of scope of the fix.