### PR TITLE
Suppress gcc deprecation warnings in pire/stub/stl.h

### DIFF
--- a/pire/stub/stl.h
+++ b/pire/stub/stl.h
@@ -51,6 +51,11 @@
 #define YASSERT(e) do {} while (0)
 #endif
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 namespace Pire {
 	template< class T, class A = std::allocator<T> >
 	class yvector: public std::vector<T, A> {
@@ -229,5 +234,9 @@ namespace Pire {
 	}
 
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/pire/stub/stl.h
+++ b/pire/stub/stl.h
@@ -51,7 +51,7 @@
 #define YASSERT(e) do {} while (0)
 #endif
 
-#ifdef __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -235,7 +235,7 @@ namespace Pire {
 
 }
 
-#ifdef __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
 #endif
 

--- a/tools/mkstl.pl
+++ b/tools/mkstl.pl
@@ -102,7 +102,7 @@ print <<EOF;
 #define YASSERT(e) do {} while (0)
 #endif
 
-#ifdef __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -166,7 +166,7 @@ print <<EOF;
 
 }
 
-#ifdef __GNUC__
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
 #endif
 

--- a/tools/mkstl.pl
+++ b/tools/mkstl.pl
@@ -102,6 +102,11 @@ print <<EOF;
 #define YASSERT(e) do {} while (0)
 #endif
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 namespace Pire {
 EOF
 
@@ -160,6 +165,10 @@ print <<EOF;
 	}
 
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #endif
 EOF


### PR DESCRIPTION
Latest versions of GCC (6.1.1, for instance) emit many (96 lines) deprecation warnings for `std::auto_ptr` used in `pire/stub/stl.h` and, consequently, `pire/pire.h`. This commit enables suppression of these warnings just for GCC and just for `stl.h`.