### PR TITLE
Clarify the comment on precedence of features

### DIFF
--- a/pire/re_lexer.h
+++ b/pire/re_lexer.h
@@ -185,7 +185,7 @@ private:
 */
 class Feature {
 public:
-	/// Precedence of features. The higher the priority, the eariler
+	/// Precedence of features. The less the priority, the earlier
 	/// will Lex() be called, and the later will Alter() and Parenthesized() be called.
 	virtual int Priority() const { return 50; }
 


### PR DESCRIPTION
IMHO the wording "the higher the priority" is somewhat misleading, as if
it naturally means "the greater the priority", the statement is wrong,
and if it means "the less the priority", it is not obvious.

Also fixed a typo in "eariler".