### PR TITLE
AdvancedCountingScanner as an alternative to CountingScanner

### DIFF
--- a/pire/determine.h
+++ b/pire/determine.h
@@ -136,6 +136,106 @@ namespace Pire {
 			}
 			return task.Success();
 		}
+
+		// Faster transition table representation for determined FSM
+		typedef yvector<size_t> DeterminedTransitions;
+
+		// Mapping of states into partitions in minimization algorithm.
+		typedef yvector<size_t> StateClassMap;
+
+		template<class Task>
+		struct MinimizeEquality : public ybinary_function<size_t, size_t, bool> {
+		public:
+
+			MinimizeEquality(const DeterminedTransitions& tbl, const yvector<Char>& letters, const StateClassMap* clMap, const Task* task) :
+				m_tbl(&tbl), m_letters(&letters), m_prev(clMap), m_task(task) {}
+
+			inline bool operator()(size_t a, size_t b) const
+			{
+				if (m_task) {
+					if (!m_task->SameClasses(a, b)) {
+						return false;
+					}
+				}
+				if (m_prev) {
+					if ((*m_prev)[a] != (*m_prev)[b])
+						return false;
+					for (yvector<Char>::const_iterator it = m_letters->begin(), ie = m_letters->end(); it != ie; ++it)
+						if ((*m_prev)[Next(a, *it)] != (*m_prev)[Next(b, *it)])
+							return false;
+				}
+				return true;
+			};
+
+		private:
+			const DeterminedTransitions* m_tbl;
+			const yvector<Char>* m_letters;
+			const StateClassMap* m_prev;
+			const Task* m_task;
+
+			size_t Next(size_t state, Char letter) const {
+				return (*m_tbl)[state * MaxChar + letter];
+			}
+		};
+
+		// Updates the mapping of states to partitions.
+		// Returns true if the mapping has changed.
+		// TODO: Think how to update only changed states
+		template<class Task>
+		bool UpdateStateClassMap(StateClassMap& clMap, const Partition<size_t, MinimizeEquality<Task>>& stPartition)
+		{
+			YASSERT(!clMap.empty());
+			bool changed = false;
+			for (size_t st = 0; st < clMap.size(); st++) {
+				size_t cl = stPartition.Representative(st);
+				if (clMap[st] != cl) {
+					clMap[st] = cl;
+					changed = true;
+				}
+			}
+			return changed;
+		}
+
+		template<class Task>
+		typename Task::Result Minimize(Task& task)
+		{
+			// Minimization algorithm is only applicable to a determined FSM.
+			if (!task.IsDetermined()) {
+				return task.Failure();
+			}
+
+			yvector<Char> distinctLetters;
+			DeterminedTransitions detTran(task.Size() * MaxChar);
+			for (auto lit = task.Letters().Begin(), lie = task.Letters().End(); lit != lie; ++lit) {
+				const auto representative = lit->first;
+				distinctLetters.push_back(representative);
+				for (size_t from = 0; from != task.Size(); ++from) {
+					const auto next = task.Next(from, representative);
+					for (auto letter : lit->second.second) {
+						detTran[from * MaxChar + letter] = next;
+					}
+				}
+			}
+
+			typedef Partition<size_t, MinimizeEquality<Task>> StateClasses;
+
+			StateClasses last(MinimizeEquality<Task>{detTran, distinctLetters, nullptr, &task});
+
+			// Make an initial states partition
+			for (size_t state = 0; state < task.Size(); ++state)
+				last.Append(state);
+
+			StateClassMap stateClassMap(task.Size());
+
+			// Iteratively split states into equality classes
+			while (UpdateStateClassMap(stateClassMap, last)) {
+				last.Split(MinimizeEquality<Task>{detTran, distinctLetters, &stateClassMap, nullptr});
+			}
+
+			task.AcceptPartition(last);
+
+			return task.Success();
+		}
 	}
 }
 

--- a/pire/extra/count.cpp
+++ b/pire/extra/count.cpp
@@ -22,13 +22,678 @@
 
 
 #include "count.h"
-#include "fsm.h"
+#include "../fsm.h"
 #include "../determine.h"
 #include "../glue.h"
 #include "../stub/lexical_cast.h"
 
 namespace Pire {
-	
+
+namespace Impl {
+
+typedef LoadedScanner::Action Action;
+typedef ymap<Char, Action> TransitionTagRow;
+typedef yvector<TransitionTagRow> TransitionTagTable;
+
+class CountingFsmTask;
+
+class CountingFsm {
+public:
+	typedef Fsm::LettersTbl LettersTbl;
+
+	enum {
+		NotMatched = 1 << 0,
+		Matched = 1 << 1,
+		Separated = 1 << 2,
+	};
+
+	CountingFsm(const Fsm& re, const Fsm& sep)
+		: mFsm(re)
+	{
+		mFsm.Canonize();
+		const auto reMatchedStates = mFsm.Finals();
+
+		auto sepOnly = sep;
+		sepOnly.Canonize();
+		for (size_t state = 0; state < sepOnly.Size(); ++state) {
+			sepOnly.SetTag(state, Separated);
+		}
+		mFsm += sepOnly;
+
+		mReInitial = mFsm.Initial();
+		const auto allowEmptySeparator = sepOnly.IsFinal(sepOnly.Initial());
+		for (auto reMatchedState : reMatchedStates) {
+			mFsm.SetTag(reMatchedState, Matched);
+			if (allowEmptySeparator) {
+				mFsm.SetFinal(reMatchedState, true);
+			}
+		}
+
+		mFsm.PrependAnything();
+		mFsm.RemoveEpsilons();
+	}
+
+	const LettersTbl& Letters() const {
+		return mFsm.Letters();
+	}
+
+	const Fsm& Determined() const {
+		return mDetermined;
+	}
+
+	Action Output(size_t from, Char letter) const {
+		const auto& row = mActions[from];
+		const auto it = row.find(letter);
+		if (it != row.end()) {
+			return it->second;
+		} else {
+			return 0;
+		}
+	}
+
+	bool Simple() const {
+		return mSimple;
+	}
+
+	bool Determine();
+	void Minimize();
+
+private:
+	void SwapTaskOutputs(CountingFsmTask& task);
+
+private:
+	Fsm mFsm;
+	size_t mReInitial;
+	Fsm mDetermined;
+	TransitionTagTable mActions;
+	bool mSimple;
+};
+
+class CountingFsmTask {
+public:
+	typedef Fsm::LettersTbl LettersTbl;
+
+	virtual ~CountingFsmTask() {}
+
+	void Connect(size_t from, size_t to, Char letter) {
+		mNewFsm.Connect(from, to, letter);
+	}
+
+	typedef bool Result;
+
+	static Result Success() {
+		return true;
+	}
+
+	static Result Failure() {
+		return false;
+	}
+
+	Fsm& Output() {
+		return mNewFsm;
+	}
+
+	TransitionTagTable& Actions() {
+		return mNewActions;
+	}
+
+protected:
+	void ResizeOutput(size_t size) {
+		mNewFsm.Resize(size);
+		mNewActions.resize(size);
+	}
+
+private:
+	Fsm mNewFsm;
+	TransitionTagTable mNewActions;
+};
+
+class CountingFsmMinimizeTask : public CountingFsmTask {
+public:
+	using CountingFsmTask::LettersTbl;
+	typedef Partition<size_t, MinimizeEquality<CountingFsmMinimizeTask>> StateClasses;
+
+	CountingFsmMinimizeTask(const CountingFsm& fsm)
+		: mFsm(fsm)
+	{}
+
+	const LettersTbl& Letters() const {
+		return mFsm.Letters();
+	}
+
+	bool IsDetermined() const {
+		return mFsm.Determined().IsDetermined();
+	}
+
+	size_t Size() const {
+		return mFsm.Determined().Size();
+	}
+
+	size_t Next(size_t state, Char letter) const {
+		const auto& tos = mFsm.Determined().Destinations(state, letter);
+		YASSERT(tos.size() == 1);
+		return *tos.begin();
+	}
+
+	void AcceptPartition(const StateClasses& partition) {
+		ResizeOutput(partition.Size());
+		auto& newFsm = Output();
+		auto& newActions = Actions();
+		newFsm.SetFinal(0, false);
+
+		// Unite equality classes into new states
+		for (size_t from = 0; from != Size(); ++from) {
+			const auto fromMinimized = partition.Index(from);
+			for (auto lit = Letters().Begin(), lie = Letters().End(); lit != lie; ++lit) {
+				const auto representative = lit->first;
+				const auto next = Next(from, representative);
+				const auto nextMinimized = partition.Index(next);
+				Connect(fromMinimized, nextMinimized, representative);
+				const auto outputs = mFsm.Output(from, representative);
+				if (outputs) {
+					newActions[fromMinimized][representative] = outputs;
+				}
+			}
+			if (mFsm.Determined().IsFinal(from)) {
+				newFsm.SetFinal(fromMinimized, true);
+			}
+		}
+
+		newFsm.SetInitial(0);
+		newFsm.SetIsDetermined(true);
+	}
+
+	bool SameClasses(size_t first, size_t second) const {
+		for (auto it = Letters().Begin(), ie = Letters().End(); it != ie; ++it) {
+			const auto letter = it->first;
+			if (mFsm.Output(first, letter) != mFsm.Output(second, letter)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+private:
+	const CountingFsm& mFsm;
+};
+
+typedef size_t RawState;
+typedef ypair<RawState, unsigned long> TaggedState;
+typedef yset<TaggedState> StateGroup;
+
+struct DeterminedState {
+public:
+	StateGroup matched;
+	StateGroup unmatched;
+	StateGroup separated;
+	StateGroup lagging;
+};
+
+bool operator < (const DeterminedState& left, const DeterminedState& right) {
+	auto asTuple = [](const DeterminedState& state) {
+		return std::tie(state.matched, state.unmatched, state.separated, state.lagging);
+	};
+
+	return asTuple(left) < asTuple(right);
+}
+
+bool InvalidCharRange(const yvector<Char>& range) {
+	for (const auto letter : range) {
+		if (letter < MaxCharUnaligned && letter != 256) {
+			return false;
+		}
+	}
+	return true;
+}
+
+class BasicCountingFsmDetermineTask : public CountingFsmTask {
+public:
+	using CountingFsmTask::LettersTbl;
+	typedef DeterminedState State;
+	typedef ymap<State, size_t> InvStates;
+
+	BasicCountingFsmDetermineTask(const Fsm& fsm, RawState reInitial)
+		: mFsm(fsm)
+		, mReInitial{reInitial}
+	{
+		mDeadStates = fsm.DeadStates();
+		for (auto lit = fsm.Letters().Begin(), lie = fsm.Letters().End(); lit != lie; ++lit) {
+			if (InvalidCharRange(lit->second.second)) {
+				mInvalidLetters.insert(lit->first);
+			}
+		}
+	}
+
+	const LettersTbl& Letters() const {
+		return mFsm.Letters();
+	}
+
+	State Initial() const {
+		return State{StateGroup{}, InitialGroup(), StateGroup{}, StateGroup{}};
+	}
+
+	bool IsRequired(const State&) const {
+		return true;
+	}
+
+	State Next(const State& state, Char letter) const {
+		if (mInvalidLetters.count(letter) != 0) {
+			AddAction(state, letter, CountingFsm::NotMatched);
+			return Initial();
+		}
+
+		auto next = PrepareNextState(state, letter);
+		AddAction(state, letter, CalculateTransitionTag(state, next));
+		PostProcessNextState(next);
+		NormalizeState(next);
+
+		return next;
+	}
+
+	void AcceptStates(const yvector<State>& states)
+	{
+		ResizeOutput(states.size());
+		auto& newFsm = Output();
+		auto& newActions = Actions();
+		newFsm.SetInitial(0);
+		newFsm.SetIsDetermined(true);
+
+		for (size_t ns = 0; ns < states.size(); ++ns) {
+			const auto& state = states[ns];
+			newFsm.SetFinal(ns, HasFinals(state.unmatched));
+
+			auto outputIt = mActionByState.find(state);
+			if (outputIt != mActionByState.end()) {
+				newActions[ns].swap(outputIt->second);
+			}
+		}
+	}
+
+protected:
+	void SplitDestinations(StateGroup& matched, StateGroup& unmatched, StateGroup& separated, const StateGroup& source, Char letter) const {
+		for (const auto& state : source) {
+			MakeTaggedStates(matched, unmatched, separated, mFsm.Destinations(state.first, letter), state.second);
+			if (mFsm.IsFinal(state.first)) {
+				// Implicit epsilon transitions from final states to reInitial after matching separator
+				MakeTaggedStates(separated, separated, separated, mFsm.Destinations(mReInitial, letter), CountingFsm::Separated);
+			}
+		}
+	}
+
+	Action CalculateTransitionTagImpl(const State& dest) const {
+		Action result = 0;
+		if (!dest.matched.empty()) {
+			result = AdvancedCountingScanner::IncrementAction;
+		} else if (dest.unmatched.empty()) {
+			if (!dest.separated.empty()) {
+				for (const auto& state : dest.separated) {
+					if (state.second == CountingFsm::Matched) {
+						result = AdvancedCountingScanner::IncrementAction;
+					}
+				}
+			} else {
+				result = AdvancedCountingScanner::ResetAction;
+				for (const auto& state : dest.lagging) {
+					if (state.second != CountingFsm::NotMatched) {
+						result |= AdvancedCountingScanner::IncrementAction;
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	unsigned long TagsOfGroup(const StateGroup& group) const {
+		unsigned long result = 0;
+		for (const auto& state : group) {
+			result |= state.second;
+		}
+		return result;
+	}
+
+	void SplitGroupByTag(StateGroup& matched, StateGroup& unmatched, StateGroup& separated, const StateGroup& source, bool useFsmTag) const {
+		for (const auto& state : source) {
+			auto tag = useFsmTag ? mFsm.Tag(state.first) : state.second;
+			if (tag == CountingFsm::Matched) {
+				matched.insert(state);
+			} else if (tag == CountingFsm::Separated) {
+				separated.insert(state);
+			} else {
+				unmatched.insert(state);
+			}
+		}
+	}
+
+	void UpdateLaggingStates(State& state, bool moveToLagging) const {
+		if (!state.matched.empty()) {
+			if (moveToLagging) {
+				state.lagging.insert(state.unmatched.cbegin(), state.unmatched.cend());
+				state.lagging.insert(state.separated.cbegin(), state.separated.cend());
+			}
+			state.unmatched.clear();
+			state.separated.clear();
+		}
+		if (state.unmatched.empty() && !state.separated.empty()) {
+			const auto unmatchedTags = TagsOfGroup(state.separated);
+			if ((unmatchedTags & CountingFsm::Matched) && (unmatchedTags != CountingFsm::Matched)) {
+				StateGroup separatedMatched;
+				for (const auto& separatedState : state.separated) {
+					if (separatedState.second == CountingFsm::Matched) {
+						separatedMatched.insert(separatedState);
+					} else if (moveToLagging) {
+						state.lagging.insert(separatedState);
+					}
+				}
+				state.separated.swap(separatedMatched);
+			}
+		}
+	}
+
+	void RemoveDuplicateLaggingStates(State& state) const {
+		const auto statesToRemove = GetRawStates({state.matched, state.unmatched, state.separated}, 0);
+		const auto unmatchedStatesToRemove = GetRawStates({state.lagging}, CountingFsm::NotMatched);
+
+		StateGroup newLagging;
+		for (const auto& taggedState : state.lagging) {
+			if (statesToRemove.count(taggedState.first) == 0) {
+				if (taggedState.second != CountingFsm::NotMatched || unmatchedStatesToRemove.count(taggedState.first) == 0) {
+					newLagging.insert(taggedState);
+				}
+			}
+		}
+		state.lagging.swap(newLagging);
+	}
+
+	void RemoveDuplicateSeparatedStates(State& state) const {
+		if (state.separated.empty()) {
+			return;
+		}
+		const auto statesToRemove = GetRawStates({state.matched, state.unmatched}, 0);
+		RemoveRawStates(state.separated, statesToRemove);
+	}
+
+	void NormalizeState(State& state) const {
+		if (!state.matched.empty()) {
+			YASSERT(state.unmatched.empty());
+			state.unmatched.swap(state.matched);
+		}
+
+		if (state.unmatched.empty() && !state.separated.empty()) {
+			state.unmatched.swap(state.separated);
+		}
+
+		if (state.unmatched.empty() && !state.lagging.empty()) {
+			State groups;
+			SplitGroupByTag(groups.matched, groups.unmatched, groups.separated, state.lagging, false);
+			if (!groups.matched.empty()) {
+				state.unmatched.swap(groups.matched);
+				state.separated.swap(groups.separated);
+				state.lagging.swap(groups.unmatched);
+			} else if (!groups.separated.empty()) {
+				state.unmatched.swap(groups.separated);
+				state.lagging.swap(groups.unmatched);
+			} else {
+				state.unmatched.swap(groups.unmatched);
+				state.lagging.swap(groups.matched); // just clear
+			}
+		}
+	}
+
+private:
+	virtual State PrepareNextState(const State& state, Char letter) const = 0;
+
+	virtual void PostProcessNextState(State& next) const = 0;
+
+	virtual Action CalculateTransitionTag(const State&, const State& dest) const {
+		return CalculateTransitionTagImpl(dest);
+	}
+
+	virtual StateGroup InitialGroup() const {
+		return StateGroup{TaggedState{mFsm.Initial(), CountingFsm::NotMatched}};
+	}
+
+	void AddAction(State from, Char letter, unsigned long value) const {
+		if (!value) {
+			return;
+		}
+		TransitionTagRow& row = mActionByState[from];
+		row[letter] = value;
+	}
+
+	void MakeTaggedStates(StateGroup& matched, StateGroup& unmatched, StateGroup& separated, const Fsm::StatesSet& destinations, unsigned long sourceTag) const {
+		for (const auto destState : destinations) {
+			if (mDeadStates.count(destState) == 0) {
+				const auto destTag = mFsm.Tag(destState);
+				if (sourceTag != CountingFsm::Matched && destTag == CountingFsm::Matched) {
+					matched.insert(ymake_pair(destState, destTag));
+				} else if (sourceTag == CountingFsm::Separated || destTag == CountingFsm::Separated) {
+					separated.insert(ymake_pair(destState, CountingFsm::Separated));
+				} else {
+					unmatched.insert(ymake_pair(destState, sourceTag));
+				}
+			}
+		}
+	}
+
+	bool HasFinals(const StateGroup& states) const {
+		for (const auto& state : states) {
+			if (mFsm.IsFinal(state.first)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	Fsm::StatesSet GetRawStates(const yvector<std::reference_wrapper<const StateGroup>> groups, unsigned long excludedTags) const {
+		Fsm::StatesSet result;
+		for (const auto& group : groups) {
+			for (const auto& taggedState : group.get()) {
+				if (!(taggedState.second & excludedTags)) {
+					result.insert(taggedState.first);
+				}
+			}
+		}
+		return result;
+	}
+
+	void RemoveRawStates(StateGroup& group, const Fsm::StatesSet& states) const {
+		StateGroup removing;
+		for (const auto& taggedState : group) {
+			if (states.count(taggedState.first) != 0) {
+				removing.insert(taggedState);
+			}
+		}
+		for (const auto& taggedState : removing) {
+			group.erase(taggedState);
+		}
+	}
+
+private:
+	const Fsm& mFsm;
+	RawState mReInitial;
+	Fsm::StatesSet mDeadStates;
+	yset<Char> mInvalidLetters;
+
+	mutable ymap<State, TransitionTagRow> mActionByState;
+};
+
+class CountingFsmDetermineTask : public BasicCountingFsmDetermineTask {
+public:
+	using BasicCountingFsmDetermineTask::State;
+	using BasicCountingFsmDetermineTask::LettersTbl;
+	using BasicCountingFsmDetermineTask::InvStates;
+
+	CountingFsmDetermineTask(const Fsm& fsm, RawState reInitial)
+		: BasicCountingFsmDetermineTask{fsm, reInitial}
+	{}
+
+private:
+	State PrepareNextState(const State& state, Char letter) const override {
+		State next;
+		SplitDestinations(next.matched, next.unmatched, next.separated, state.unmatched, letter);
+		SplitDestinations(next.separated, next.separated, next.separated, state.separated, letter);
+		SplitDestinations(next.lagging, next.lagging, next.lagging, state.lagging, letter);
+		return next;
+	}
+
+	void PostProcessNextState(State& next) const override {
+		UpdateLaggingStates(next, true);
+		RemoveDuplicateLaggingStates(next);
+		RemoveDuplicateSeparatedStates(next);
+	}
+};
+
+class SimpleCountingFsmDetermineTask : public BasicCountingFsmDetermineTask {
+public:
+	using BasicCountingFsmDetermineTask::State;
+	using BasicCountingFsmDetermineTask::LettersTbl;
+	using BasicCountingFsmDetermineTask::InvStates;
+
+	static constexpr unsigned long MixedTags = CountingFsm::Separated | CountingFsm::Matched;
+
+	SimpleCountingFsmDetermineTask(const Fsm& fsm, RawState reInitial)
+		: BasicCountingFsmDetermineTask{fsm, reInitial}
+		, mStartState{reInitial, CountingFsm::NotMatched}
+	{}
+
+private:
+	State PrepareNextState(const State& state, Char letter) const override {
+		State next;
+		auto from = state;
+		const auto fromIsEmpty = IsEmptyState(from);
+		if (fromIsEmpty) {
+			from.unmatched.insert(mStartState);
+		}
+		YASSERT(IsValidState(from));
+
+		SplitDestinations(next.matched, next.unmatched, next.separated, from.unmatched, letter);
+		if (next.matched.empty() && !next.separated.empty()) {
+			if (next.unmatched.empty()) {
+				SplitSeparatedByFsmTag(next);
+				if (next.separated.size() > 1) {
+					RemoveDuplicateSeparatedStates(next);
+				}
+				if (next.unmatched.empty()) {
+					next.unmatched.swap(next.separated);
+				}
+			} else {
+				ChooseOneSeparatedState(next);
+			}
+		}
+		if (next.matched.empty() && next.separated.empty() && !from.separated.empty()) {
+			if (!next.unmatched.empty()) {
+				ChooseOneDestState(next.separated, from.separated, letter);
+			} else {
+				SplitDestinations(next.matched, next.unmatched, next.separated, from.separated, letter);
+				if (next.matched.empty() && !next.separated.empty()) {
+					SplitSeparatedByFsmTag(next);
+				}
+			}
+			ChooseOneSeparatedState(next);
+		}
+		if (!fromIsEmpty && IsEmptyState(next)) {
+			ChooseOneDestState(next.lagging, StateGroup{mStartState}, letter);
+		}
+
+		return next;
+	}
+
+	void PostProcessNextState(State& next) const override {
+		if (!next.lagging.empty()) {
+			next.unmatched.swap(next.lagging);
+		}
+		UpdateLaggingStates(next, false);
+		RemoveDuplicateSeparatedStates(next);
+	}
+
+	Action CalculateTransitionTag(const State& source, const State& dest) const override {
+		Action tag = CalculateTransitionTagImpl(dest);
+		if (!((TagsOfGroup(source.unmatched) | TagsOfGroup(source.separated)) & MixedTags)) {
+			tag &= AdvancedCountingScanner::IncrementAction;
+		}
+		return tag;
+	}
+
+	StateGroup InitialGroup() const override {
+		return StateGroup{};
+	}
+
+	bool IsEmptyState(const State& state) const {
+		return state.matched.empty() && state.unmatched.empty() && state.separated.empty() && state.lagging.empty();
+	}
+
+	bool IsValidState(const State& state) const {
+		return state.matched.empty() && state.unmatched.size() <= 1 && state.separated.size() <= 1 && state.lagging.empty();
+	}
+
+	void SplitSeparatedByFsmTag(State& state) const {
+		YASSERT(state.unmatched.empty());
+		StateGroup separated;
+		separated.swap(state.separated);
+		SplitGroupByTag(state.matched, state.unmatched, state.separated, separated, true);
+	}
+
+	void ChooseOneDestState(StateGroup& dest, const StateGroup& source, Char letter) const {
+		State destState;
+		SplitDestinations(destState.matched, destState.unmatched, destState.separated, source, letter);
+		if (!destState.matched.empty()) {
+			dest.swap(destState.matched);
+		} else if (!destState.separated.empty()) {
+			dest.swap(destState.separated);
+		} else if (!destState.unmatched.empty()) {
+			dest.swap(destState.unmatched);
+		}
+	}
+
+	void ChooseOneSeparatedState(State& state) const {
+		if (state.separated.size() <= 1) {
+			return;
+		}
+		RemoveDuplicateSeparatedStates(state);
+		State splitted;
+		SplitGroupByTag(splitted.matched, splitted.unmatched, splitted.separated, state.separated, true);
+		if (!splitted.separated.empty()) {
+			state.separated.swap(splitted.separated);
+		} else if (!splitted.matched.empty()) {
+			state.separated.swap(splitted.matched);
+		}
+	}
+
+private:
+	TaggedState mStartState;
+};
+
+bool CountingFsm::Determine() {
+	CountingFsmDetermineTask task{mFsm, mReInitial};
+	size_t maxSize = mFsm.Size() * 4096;
+	if (Pire::Impl::Determine(task, maxSize)) {
+		SwapTaskOutputs(task);
+		mSimple = false;
+	} else {
+		SimpleCountingFsmDetermineTask simpleTask{mFsm, mReInitial};
+		if (Pire::Impl::Determine(simpleTask, std::numeric_limits<size_t>::max())) {
+			SwapTaskOutputs(simpleTask);
+			mSimple = true;
+		} else {
+			return false;
+		}
+	}
+	return true;
+}
+
+void CountingFsm::Minimize() {
+	CountingFsmMinimizeTask task{*this};
+	Pire::Impl::Minimize(task);
+	SwapTaskOutputs(task);
+}
+
+void CountingFsm::SwapTaskOutputs(CountingFsmTask& task) {
+	task.Output().Swap(mDetermined);
+	task.Actions().swap(mActions);
+}
+
+}
+
 namespace {
 	Pire::Fsm FsmForDot() { Pire::Fsm f; f.AppendDot(); return f; }
 	Pire::Fsm FsmForChar(Pire::Char c) { Pire::Fsm f; f.AppendSpecial(c); return f; }
@@ -126,41 +791,70 @@ CountingScanner::CountingScanner(const Fsm& re, const Fsm& sep)
 	BuildScanner(sq, *this);
 }
 
+AdvancedCountingScanner::AdvancedCountingScanner(const Fsm& re, const Fsm& sep, bool* simple)
+{
+	Impl::CountingFsm countingFsm{re, sep};
+	if (!countingFsm.Determine()) {
+		throw Error("regexp pattern too complicated");
+	}
+	countingFsm.Minimize();
+	if (simple) {
+		*simple = countingFsm.Simple();
+	}
+
+	const auto& determined = countingFsm.Determined();
+	const auto& letters = countingFsm.Letters();
+
+	Init(determined.Size(), letters, determined.Initial(), 1);
+
+	for (size_t from = 0; from != determined.Size(); ++from) {
+		for (auto lit = letters.Begin(), lie = letters.End(); lit != lie; ++lit) {
+			const auto letter = lit->first;
+			const auto& tos = determined.Destinations(from, letter);
+			YASSERT(tos.size() == 1);
+			SetJump(from, letter, *tos.begin(), RemapAction(countingFsm.Output(from, letter)));
+		}
+	}
+}
 
 namespace Impl {
 
-class CountingScannerGlueTask: public ScannerGlueCommon<CountingScanner> {
+template<class Scanner>
+class CountingScannerGlueTask: public ScannerGlueCommon<Scanner> {
 public:
+	using typename ScannerGlueCommon<Scanner>::State;
+	using TAction = typename Scanner::Action;
+	using InternalState = typename Scanner::InternalState;
 	typedef ymap<State, size_t> InvStates;
 	
-	CountingScannerGlueTask(const CountingScanner& lhs, const CountingScanner& rhs)
-		: ScannerGlueCommon<CountingScanner>(lhs, rhs, LettersEquality<CountingScanner>(lhs.m_letters, rhs.m_letters))
+	CountingScannerGlueTask(const Scanner& lhs, const Scanner& rhs)
+		: ScannerGlueCommon<Scanner>(lhs, rhs, LettersEquality<Scanner>(lhs.m_letters, rhs.m_letters))
 	{
 	}
 	
 	void AcceptStates(const yvector<State>& states)
 	{
 		States = states;
-		SetSc(new CountingScanner);
-		Sc().Init(states.size(), Letters(), 0, Lhs().RegexpsCount() + Rhs().RegexpsCount());
 		
+		this->SetSc(new Scanner);
+		this->Sc().Init(states.size(), this->Letters(), 0, this->Lhs().RegexpsCount() + this->Rhs().RegexpsCount());
 		for (size_t i = 0; i < states.size(); ++i)
-			Sc().SetTag(i, Lhs().m_tags[Lhs().StateIdx(states[i].first)] | (Rhs().m_tags[Rhs().StateIdx(states[i].second)] << 3));
+			this->Sc().SetTag(i, this->Lhs().m_tags[this->Lhs().StateIdx(states[i].first)] | (this->Rhs().m_tags[this->Rhs().StateIdx(states[i].second)] << 3));
 	}
 	
 	void Connect(size_t from, size_t to, Char letter)
 	{
-		Sc().SetJump(from, letter, to,
-			Action(Lhs(), States[from].first, letter) | (Action(Rhs(), States[from].second, letter) << Lhs().RegexpsCount()));
+		this->Sc().SetJump(from, letter, to,
+			Action(this->Lhs(), States[from].first, letter) | (Action(this->Rhs(), States[from].second, letter) << this->Lhs().RegexpsCount()));
 	}
 			
 private:
 	yvector<State> States;
-	CountingScanner::Action Action(const CountingScanner& sc, CountingScanner::InternalState state, Char letter) const
+	TAction Action(const Scanner& sc, InternalState state, Char letter) const
 	{
 		size_t state_index = sc.StateIdx(state);
 		size_t transition_index = sc.TransitionIndex(state_index, letter);
-		const CountingScanner::Transition& tr = sc.m_jumps[transition_index];
+		const auto& tr = sc.m_jumps[transition_index];
 		return tr.action;
 	}
 };
@@ -169,8 +863,15 @@ private:
 	
 CountingScanner CountingScanner::Glue(const CountingScanner& lhs, const CountingScanner& rhs, size_t maxSize /* = 0 */)
 {
-	static const size_t DefMaxSize = 250000;    
-	Impl::CountingScannerGlueTask task(lhs, rhs);
+	static const size_t DefMaxSize = 250000;
+	Impl::CountingScannerGlueTask<CountingScanner> task(lhs, rhs);
+	return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);
+}
+
+AdvancedCountingScanner AdvancedCountingScanner::Glue(const AdvancedCountingScanner& lhs, const AdvancedCountingScanner& rhs, size_t maxSize /* = 0 */)
+{
+	static const size_t DefMaxSize = 250000;
+	Impl::CountingScannerGlueTask<AdvancedCountingScanner> task(lhs, rhs);
 	return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);
 }
 

--- a/pire/extra/count.cpp
+++ b/pire/extra/count.cpp
@@ -26,6 +26,7 @@
 #include "../determine.h"
 #include "../glue.h"
 #include "../stub/lexical_cast.h"
+#include <tuple>
 
 namespace Pire {
 
@@ -47,21 +48,20 @@ public:
 		Separated = 1 << 2,
 	};
 
-	CountingFsm(const Fsm& re, const Fsm& sep)
-		: mFsm(re)
+	explicit CountingFsm(Fsm re, Fsm sep)
+		: mFsm(std::move(re))
 	{
 		mFsm.Canonize();
 		const auto reMatchedStates = mFsm.Finals();
 
-		auto sepOnly = sep;
-		sepOnly.Canonize();
-		for (size_t state = 0; state < sepOnly.Size(); ++state) {
-			sepOnly.SetTag(state, Separated);
+		sep.Canonize();
+		for (size_t state = 0; state < sep.Size(); ++state) {
+			sep.SetTag(state, Separated);
 		}
-		mFsm += sepOnly;
+		mFsm += sep;
 
 		mReInitial = mFsm.Initial();
-		const auto allowEmptySeparator = sepOnly.IsFinal(sepOnly.Initial());
+		const auto allowEmptySeparator = sep.IsFinal(sep.Initial());
 		for (auto reMatchedState : reMatchedStates) {
 			mFsm.SetTag(reMatchedState, Matched);
 			if (allowEmptySeparator) {
@@ -153,7 +153,7 @@ public:
 	using CountingFsmTask::LettersTbl;
 	typedef Partition<size_t, MinimizeEquality<CountingFsmMinimizeTask>> StateClasses;
 
-	CountingFsmMinimizeTask(const CountingFsm& fsm)
+	explicit CountingFsmMinimizeTask(const CountingFsm& fsm)
 		: mFsm(fsm)
 	{}
 
@@ -252,7 +252,7 @@ public:
 	typedef DeterminedState State;
 	typedef ymap<State, size_t> InvStates;
 
-	BasicCountingFsmDetermineTask(const Fsm& fsm, RawState reInitial)
+	explicit BasicCountingFsmDetermineTask(const Fsm& fsm, RawState reInitial)
 		: mFsm(fsm)
 		, mReInitial{reInitial}
 	{
@@ -523,7 +523,7 @@ public:
 	using BasicCountingFsmDetermineTask::LettersTbl;
 	using BasicCountingFsmDetermineTask::InvStates;
 
-	CountingFsmDetermineTask(const Fsm& fsm, RawState reInitial)
+	explicit CountingFsmDetermineTask(const Fsm& fsm, RawState reInitial)
 		: BasicCountingFsmDetermineTask{fsm, reInitial}
 	{}
 

--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -31,10 +31,11 @@ namespace Pire {
 class Fsm;
 
 namespace Impl {
-    template<class T>
-    class ScannerGlueCommon;
+	template<class T>
+	class ScannerGlueCommon;
 
-    class CountingScannerGlueTask;
+	template<class T>
+	class CountingScannerGlueTask;
 };
 
 template<size_t I>
@@ -107,7 +108,8 @@ public:
  * given regexp separated by another regexp
  * in input text.
  */
-class CountingScanner: public LoadedScanner {
+template<class DerivedScanner>
+class BaseCountingScanner: public LoadedScanner {
 public:
 	enum {
 		IncrementAction = 1,
@@ -115,7 +117,6 @@ public:
 
 		FinalFlag = 0,
 		DeadFlag = 1,
-		Matched = 2
 	};
 
 	static const size_t OPTIMAL_RE_COUNT = 4;
@@ -129,7 +130,7 @@ public:
 		ui32 m_total[MAX_RE_COUNT];
 		size_t m_updatedMask;
 
-		friend class CountingScanner;
+		friend class BaseCountingScanner;
 
 		template<size_t I>
 		friend class IncrementPerformer;
@@ -148,8 +149,6 @@ public:
 #endif
 	};
 
-	static CountingScanner Glue(const CountingScanner& a, const CountingScanner& b, size_t maxSize = 0);
-
 	void Initialize(State& state) const
 	{
 		state.m_state = m.initial;
@@ -158,20 +157,10 @@ public:
 		state.m_updatedMask = 0;
 	}
 
-	template<size_t ActualReCount>
-	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
-	void TakeActionImpl(State& s, Action a) const
-	{
-		if (a & IncrementMask)
-			PerformIncrement<ActualReCount>(s, a);
-		if (a & ResetMask)
-			PerformReset<ActualReCount>(s, a);
-	}
-
 	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
 	void TakeAction(State& s, Action a) const
 	{
-		TakeActionImpl<OPTIMAL_RE_COUNT>(s, a);
+		static_cast<const DerivedScanner*>(this)->template TakeActionImpl<OPTIMAL_RE_COUNT>(s, a);
 	}
 
 	bool CanStop(const State&) const { return false; }
@@ -203,17 +192,17 @@ public:
 
 	bool Dead(const State&) const { return false; }
 
-	CountingScanner() {}
-	CountingScanner(const CountingScanner& s): LoadedScanner(s) {}
-	CountingScanner(const Fsm& re, const Fsm& sep);
+	BaseCountingScanner() {}
+	BaseCountingScanner(const BaseCountingScanner& s): LoadedScanner(s) {}
 
-	void Swap(CountingScanner& s) { LoadedScanner::Swap(s); }
-	CountingScanner& operator = (const CountingScanner& s) { CountingScanner(s).Swap(*this); return *this; }
+	void Swap(BaseCountingScanner& s) { LoadedScanner::Swap(s); }
+	BaseCountingScanner& operator = (const BaseCountingScanner& s) { BaseCountingScanner(s).Swap(*this); return *this; }
 
 	size_t StateIndex(const State& s) const { return StateIdx(s.m_state); }
 
-private:
+protected:
 	using LoadedScanner::Init;
+	using LoadedScanner::InternalState;
 
 	template<size_t ActualReCount>
 	void PerformIncrement(State& s, Action mask) const
@@ -239,7 +228,30 @@ private:
 		Transition x = reinterpret_cast<const Transition*>(s)[Translate(c)];
 		s += SignExtend(x.shift);
 	}
+};
 
+class CountingScanner : public BaseCountingScanner<CountingScanner> {
+public:
+	enum {
+		Matched = 2,
+	};
+	
+	CountingScanner() {}
+	CountingScanner(const Fsm& re, const Fsm& sep);
+
+	static CountingScanner Glue(const CountingScanner& a, const CountingScanner& b, size_t maxSize = 0);
+
+	template<size_t ActualReCount>
+	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+	void TakeActionImpl(State& s, Action a) const
+	{
+		if (a & IncrementMask)
+			PerformIncrement<ActualReCount>(s, a);
+		if (a & ResetMask)
+			PerformReset<ActualReCount>(s, a);
+	}
+
+private:
 	Action RemapAction(Action action)
 	{
 		if (action == (Matched | DeadFlag))
@@ -250,10 +262,45 @@ private:
 			return 0;
 	}
 
-	typedef LoadedScanner::InternalState InternalState;
 	friend void BuildScanner<CountingScanner>(const Fsm&, CountingScanner&);
 	friend class Impl::ScannerGlueCommon<CountingScanner>;
-	friend class Impl::CountingScannerGlueTask;
+	friend class Impl::CountingScannerGlueTask<CountingScanner>;
+};
+
+class AdvancedCountingScanner : public BaseCountingScanner<AdvancedCountingScanner> {
+public:
+	AdvancedCountingScanner() {}
+	AdvancedCountingScanner(const Fsm& re, const Fsm& sep, bool* simple = nullptr);
+
+	static AdvancedCountingScanner Glue(const AdvancedCountingScanner& a, const AdvancedCountingScanner& b, size_t maxSize = 0);
+
+	template<size_t ActualReCount>
+	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+	void TakeActionImpl(State& s, Action a) const
+	{
+		if (a & ResetMask) {
+			PerformReset<ActualReCount>(s, a);
+		}
+		if (a & IncrementMask) {
+			PerformIncrement<ActualReCount>(s, a);
+		}
+	}
+
+private:
+	Action RemapAction(Action action)
+	{
+		Action result = 0;
+		if (action & ResetAction) {
+			result = 1 << MAX_RE_COUNT;
+		}
+		if (action & IncrementAction) {
+			result |= 1;
+		}
+		return result;
+	}
+
+	friend class Impl::ScannerGlueCommon<AdvancedCountingScanner>;
+	friend class Impl::CountingScannerGlueTask<AdvancedCountingScanner>;
 };
 
 }

--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -192,11 +192,7 @@ public:
 
 	bool Dead(const State&) const { return false; }
 
-	BaseCountingScanner() {}
-	BaseCountingScanner(const BaseCountingScanner& s): LoadedScanner(s) {}
-
-	void Swap(BaseCountingScanner& s) { LoadedScanner::Swap(s); }
-	BaseCountingScanner& operator = (const BaseCountingScanner& s) { BaseCountingScanner(s).Swap(*this); return *this; }
+	using LoadedScanner::Swap;
 
 	size_t StateIndex(const State& s) const { return StateIdx(s.m_state); }
 

--- a/pire/fsm.cpp
+++ b/pire/fsm.cpp
@@ -1033,63 +1033,96 @@ bool Fsm::Determine(size_t maxsize /* = 0 */)
 		return false;
 }
 
-
-// Faster transition table representation for determined FSM
-typedef yvector<size_t> DeterminedTransitions;
-
-// Mapping of states into partitions in minimization algorithm.
-typedef yvector<size_t> StateClassMap;
-
-struct MinimizeEquality: public ybinary_function<size_t, size_t, bool> {
+namespace Impl {
+class FsmMinimizeTask {
 public:
+	typedef Fsm::LettersTbl LettersTbl;
+	typedef Partition<size_t, MinimizeEquality<FsmMinimizeTask>> StateClasses;
 
-	MinimizeEquality(const DeterminedTransitions& tbl, const yvector<Char>& letters, const StateClassMap* clMap):
-		m_tbl(&tbl), m_letters(&letters), m_prev(clMap), m_final(0) {}
+	FsmMinimizeTask(const Fsm& fsm)
+		: mFsm(fsm)
+	{}
 
-	MinimizeEquality(const DeterminedTransitions& tbl, const yvector<Char>& letters, const Fsm::FinalTable& final):
-		m_tbl(&tbl), m_letters(&letters), m_prev(0), m_final(&final) {}
+	const LettersTbl& Letters() const {
+		return mFsm.Letters();
+	}
 
-	inline bool operator()(size_t a, size_t b) const
-	{
-		if (m_final && (m_final->find(a) != m_final->end()) != (m_final->find(b) != m_final->end()))
-			return false;
-		if (m_prev) {
-			if ((*m_prev)[a] != (*m_prev)[b])
-				return false;
-			for (yvector<Char>::const_iterator it = m_letters->begin(), ie = m_letters->end(); it != ie; ++it)
-				if ((*m_prev)[Next(a, *it)] != (*m_prev)[Next(b, *it)])
-					return false;
+	bool IsDetermined() const {
+		return mFsm.IsDetermined();
+	}
+
+	size_t Size() const {
+		return mFsm.Size();
+	}
+
+	size_t Next(size_t state, Char letter) const {
+		const Fsm::StatesSet& tos = mFsm.Destinations(state, letter);
+		YASSERT(tos.size() == 1);
+		return *tos.begin();
+	}
+
+	void AcceptPartition(const StateClasses& partition) {
+		mNewFsm.Resize(partition.Size());
+		mNewFsm.letters = mFsm.letters;
+		mNewFsm.determined = mFsm.determined;
+		mNewFsm.m_sparsed = mFsm.m_sparsed;
+		mNewFsm.SetFinal(0, false);
+
+		// Unite equality classes into new states
+		size_t fromIdx = 0;
+		for (Fsm::TransitionTable::const_iterator from = mFsm.m_transitions.begin(), fromEnd = mFsm.m_transitions.end(); from != fromEnd; ++from, ++fromIdx) {
+			size_t dest = partition.Index(fromIdx);
+			PIRE_IFDEBUG(Cdbg << "[min] State " << fromIdx << " becomes state " << dest << Endl);
+			for (Fsm::TransitionRow::const_iterator letter = from->begin(), letterEnd = from->end(); letter != letterEnd; ++letter) {
+				YASSERT(letter->second.size() == 1 || !"FSM::minimize(): FSM not deterministic");
+				mNewFsm.Connect(dest, partition.Index(*letter->second.begin()), letter->first);
+			}
+			if (mFsm.IsFinal(fromIdx)) {
+				mNewFsm.SetFinal(dest, true);
+				PIRE_IFDEBUG(Cdbg << "[min] New state " << dest << " becomes final because of old state " << fromIdx << Endl);
+			}
+
+			// Append tags
+			Fsm::Tags::const_iterator ti = mFsm.tags.find(fromIdx);
+			if (ti != mFsm.tags.end()) {
+				mNewFsm.tags[dest] |= ti->second;
+				PIRE_IFDEBUG(Cdbg << "[min] New state " << dest << " carries tag " << ti->second << " because of old state " << fromIdx << Endl);
+			}
 		}
+		mNewFsm.initial = partition.Representative(mFsm.initial);
+
+		// Restore outputs
+		for (auto oit = mFsm.outputs.cbegin(), oie = mFsm.outputs.cend(); oit != oie; ++oit)
+			for (auto oit2 = oit->second.cbegin(), oie2 = oit->second.cend(); oit2 != oie2; ++oit2)
+				mNewFsm.outputs[partition.Index(oit->first)].insert(ymake_pair(partition.Index(oit2->first), oit2->second));
+	}
+
+	void Connect(size_t from, size_t to, Char letter) {
+		mNewFsm.Connect(from, to, letter);
+	}
+
+	bool SameClasses(size_t first, size_t second) const {
+		return mFsm.IsFinal(first) == mFsm.IsFinal(second);
+	}
+
+	typedef bool Result;
+
+	Result Success() {
 		return true;
-	};
+	}
+
+	Result Failure() {
+		return false;
+	}
+
+	Fsm& Output() {
+		return mNewFsm;
+	}
 
 private:
-	const DeterminedTransitions* m_tbl;
-	const yvector<Char>* m_letters;
-	const StateClassMap* m_prev;
-	const Fsm::FinalTable* m_final;
-
-	size_t Next(size_t state, Char letter) const
-	{
-		return (*m_tbl)[state * MaxChar + letter];
-	}
+	const Fsm& mFsm;
+	Fsm mNewFsm;
 };
-
-// Updates the mapping of states to partitions.
-// Returns true if the mapping has changed.
-// TODO: Think how to update only changed states
-bool UpdateStateClassMap(StateClassMap& clMap, const Partition<size_t, MinimizeEquality>& stPartition)
-{
-	YASSERT(clMap.size() != 0);
-	bool changed = false;
-	for (size_t st = 0; st < clMap.size(); st++) {
-		size_t cl = stPartition.Representative(st);
-		if (clMap[st] != cl) {
-			clMap[st] = cl;
-			changed = true;
-		}
-	}
-	return changed;
 }
 
 void Fsm::Minimize()
@@ -1097,85 +1130,10 @@ void Fsm::Minimize()
 	// Minimization algorithm is only applicable to a determined FSM.
 	YASSERT(determined);
 
-	PIRE_IFDEBUG(Cdbg << "=== Minimizing ===" << Endl << *this << Endl);
-
-	DeterminedTransitions detTran(Size() * MaxChar);
-	for (TransitionTable::const_iterator j = m_transitions.begin(), je = m_transitions.end(); j != je; ++j) {
-		for (TransitionRow::const_iterator k = j->begin(), ke = j->end(); k != ke; ++k) {
-			YASSERT(k->second.size() == 1);
-			detTran[(j - m_transitions.begin()) * MaxChar + k->first] = *(k->second.begin());
-		}
+	Impl::FsmMinimizeTask task{*this};
+	if (Pire::Impl::Minimize(task)) {
+		task.Output().Swap(*this);
 	}
-
-	// Precompute letter classes
-	yvector<Char> distinctLetters;
-	distinctLetters.reserve(letters.Size());
-	for (LettersTbl::ConstIterator lit = letters.Begin(); lit != letters.End(); ++lit) {
-		distinctLetters.push_back(lit->first);
-	}
-
-	typedef Partition<size_t, MinimizeEquality> StateClasses;
-
-	StateClasses last(MinimizeEquality(detTran, distinctLetters, m_final));
-
-	PIRE_IFDEBUG(Cdbg << "Initial finals: { " << Join(m_final.begin(), m_final.end(), ", ") << " }" << Endl);
-	// Make an initial states partition
-	for (size_t state = 0; state < Size(); ++state)
-		last.Append(state);
-
-	StateClassMap stateClassMap(Size());
-
-	PIRE_IFDEBUG(unsigned cnt = 0);
-	// Iteratively split states into equality classes
-	while (UpdateStateClassMap(stateClassMap, last)) {
-		PIRE_IFDEBUG(Cdbg << "Stage " << cnt++ << ": state classes = " << last << Endl);
-		last.Split(MinimizeEquality(detTran, distinctLetters, &stateClassMap));
-	}
-
-	// Resize FSM
-	TransitionTable oldTransitions;
-	FinalTable oldFinal;
-	Outputs oldOutputs;
-	Tags oldTags;
-	m_transitions.swap(oldTransitions);
-	m_final.swap(oldFinal);
-	outputs.swap(oldOutputs);
-	tags.swap(oldTags);
-	Resize(last.Size());
-	PIRE_IFDEBUG(Cdbg << "[min] Resizing FSM to " << last.Size() << " states" << Endl);
-
-	// Union equality classes into new states
-	size_t fromIdx = 0;
-	for (TransitionTable::iterator from = oldTransitions.begin(), fromEnd = oldTransitions.end(); from != fromEnd; ++from, ++fromIdx) {
-		size_t dest = last.Index(fromIdx);
-		PIRE_IFDEBUG(Cdbg << "[min] State " << fromIdx << " becomes state " << dest << Endl);
-		for (TransitionRow::iterator letter = from->begin(), letterEnd = from->end(); letter != letterEnd; ++letter) {
-			YASSERT(letter->second.size() == 1 || !"FSM::minimize(): FSM not deterministic");
-			PIRE_IFDEBUG(Cdbg << "[min] connecting " << dest << " --" << CharDump(letter->first) << "--> "
-				<< last.Index(*letter->second.begin()) << Endl);
-			Connect(dest, last.Index(*letter->second.begin()), letter->first);
-		}
-		if (oldFinal.find(fromIdx) != oldFinal.end()) {
-			SetFinal(dest, true);
-			PIRE_IFDEBUG(Cdbg << "[min] New state " << dest << " becomes final because of old state " << fromIdx << Endl);
-		}
-
-		// Append tags
-		Tags::iterator ti = oldTags.find(fromIdx);
-		if (ti != oldTags.end()) {
-			tags[dest] |= ti->second;
-			PIRE_IFDEBUG(Cdbg << "[min] New state " << dest << " carries tag " << ti->second << " because of old state " << fromIdx << Endl);
-		}
-	}
-	initial = last.Representative(initial);
-
-	// Restore outputs
-	for (Outputs::iterator oit = oldOutputs.begin(), oie = oldOutputs.end(); oit != oie; ++oit)
-		for (Outputs::value_type::second_type::iterator oit2 = oit->second.begin(), oie2 = oit->second.end(); oit2 != oie2; ++oit2)
-			outputs[last.Index(oit->first)].insert(ymake_pair(last.Index(oit2->first), oit2->second));
-
-	ClearHints();
-	PIRE_IFDEBUG(Cdbg << "=== Minimized (" << Size() << " states) ===" << Endl << *this << Endl);
 }
 
 Fsm& Fsm::Canonize(size_t maxSize /* = 0 */)

--- a/pire/fsm.cpp
+++ b/pire/fsm.cpp
@@ -1039,7 +1039,7 @@ public:
 	typedef Fsm::LettersTbl LettersTbl;
 	typedef Partition<size_t, MinimizeEquality<FsmMinimizeTask>> StateClasses;
 
-	FsmMinimizeTask(const Fsm& fsm)
+	explicit FsmMinimizeTask(const Fsm& fsm)
 		: mFsm(fsm)
 	{}
 

--- a/pire/fsm.h
+++ b/pire/fsm.h
@@ -33,6 +33,7 @@ namespace Pire {
 
 	namespace Impl {
 		class FsmDetermineTask;
+		class FsmMinimizeTask;
 	}
 
 	/// A Flying Spaghetti Monster... no, just a Finite State Machine.
@@ -242,6 +243,7 @@ namespace Pire {
 		void ClearHints() { isAlternative = false; }
 		
 		friend class Impl::FsmDetermineTask;
+		friend class Impl::FsmMinimizeTask;
 	};
 
 	template<class Scanner>

--- a/pire/stub/stl.h
+++ b/pire/stub/stl.h
@@ -43,6 +43,8 @@
 #include <stdexcept>
 #include <iterator>
 #include <functional>
+#include <tuple>
+#include <initializer_list>
 #include <assert.h>
 
 #ifdef PIRE_CHECKED
@@ -61,6 +63,8 @@ namespace Pire {
 	class yvector: public std::vector<T, A> {
 	public:
 		yvector(): std::vector<T, A>() {}
+
+		yvector(std::initializer_list<T> il): std::vector<T, A>(il) {}
 
 		template<class Arg1>
 		yvector(Arg1 arg1): std::vector<T, A>(arg1) {}
@@ -121,6 +125,8 @@ namespace Pire {
 	class yset: public std::set<T, C, A> {
 	public:
 		yset(): std::set<T, C, A>() {}
+
+		yset(std::initializer_list<T> il): std::set<T, C, A>(il) {}
 
 		template<class Arg1>
 		yset(Arg1 arg1): std::set<T, C, A>(arg1) {}

--- a/pire/stub/stl.h
+++ b/pire/stub/stl.h
@@ -43,7 +43,6 @@
 #include <stdexcept>
 #include <iterator>
 #include <functional>
-#include <tuple>
 #include <initializer_list>
 #include <assert.h>
 


### PR DESCRIPTION
There are 3 main differences, see unit tests.

1. AdvancedCountingScanner never enters a dead state, see test `Count("[a-z\320\260-\321\217]+", " +",	" \320\260\320\260\320\220 abc def \320\260  cd")`
2. AdvancedCountingScanner returns 1 for `Count("a", "b", "aaa")`, while CountingScanner returns 0 there.
3. AdvancedCountingScanner better handles complex regular expressions, see test CountGreedy.
