### PR TITLE
NoGlueLimitCountingScanner

### DIFF
--- a/pire/defs.h
+++ b/pire/defs.h
@@ -32,10 +32,14 @@
 #if defined(_MSC_VER)
 #define PIRE_HAVE_DECLSPEC_ALIGN
 #else
+#ifndef PIRE_HAVE_ALIGNAS
 #define PIRE_HAVE_ALIGNAS
 #endif
+#endif
 
+#ifndef PIRE_HAVE_LAMBDAS
 #define PIRE_HAVE_LAMBDAS
+#endif
 
 namespace Pire {
 

--- a/pire/extra/capture.cpp
+++ b/pire/extra/capture.cpp
@@ -97,11 +97,12 @@ namespace {
 			fsm.ConnectFinal(fsm.Size() - 1);
 
 			for (size_t state = 0; state < fsm.Size() - 1; ++state)
-				if (fsm.IsFinal(state))
+				if (fsm.IsFinal(state)) {
 					if (greedy)
 						fsm.SetOutput(state, fsm.Size() - 1, SlowCapturingScanner::EndRepetition);
 					else
 						fsm.SetOutput(state, fsm.Size() - 1, SlowCapturingScanner::EndNonGreedyRepetition);
+                        }
 			fsm.ClearFinal();
 			fsm.SetFinal(fsm.Size() - 1, true);
 			fsm.SetIsDetermined(false);

--- a/pire/extra/capture.cpp
+++ b/pire/extra/capture.cpp
@@ -96,13 +96,14 @@ namespace {
 			fsm.Resize(fsm.Size() + 1);
 			fsm.ConnectFinal(fsm.Size() - 1);
 
-			for (size_t state = 0; state < fsm.Size() - 1; ++state)
+			for (size_t state = 0; state < fsm.Size() - 1; ++state) {
 				if (fsm.IsFinal(state)) {
 					if (greedy)
 						fsm.SetOutput(state, fsm.Size() - 1, SlowCapturingScanner::EndRepetition);
 					else
 						fsm.SetOutput(state, fsm.Size() - 1, SlowCapturingScanner::EndNonGreedyRepetition);
-                        }
+				}
+			}
 			fsm.ClearFinal();
 			fsm.SetFinal(fsm.Size() - 1, true);
 			fsm.SetIsDetermined(false);

--- a/pire/extra/capture.h
+++ b/pire/extra/capture.h
@@ -357,6 +357,8 @@ public:
 					return m_nothing;
 				case GreedyRepetition:
 					return m_greedy;
+                                default:
+                                        return m_greedy;
 			}
 		}
 
@@ -369,6 +371,8 @@ public:
 					return m_nothing;
 				case GreedyRepetition:
 					return m_greedy;
+                                default:
+                                        return m_greedy;
 			}
 		}
 	};

--- a/pire/extra/capture.h
+++ b/pire/extra/capture.h
@@ -357,8 +357,8 @@ public:
 					return m_nothing;
 				case GreedyRepetition:
 					return m_greedy;
-                                default:
-                                        return m_greedy;
+				default:
+					return m_greedy;
 			}
 		}
 

--- a/pire/extra/count.cpp
+++ b/pire/extra/count.cpp
@@ -863,6 +863,9 @@ private:
 	
 CountingScanner CountingScanner::Glue(const CountingScanner& lhs, const CountingScanner& rhs, size_t maxSize /* = 0 */)
 {
+    if (lhs.RegexpsCount() + rhs.RegexpsCount() > MAX_RE_COUNT) {
+        return CountingScanner();
+    }
 	static constexpr size_t DefMaxSize = 250000;
 	Impl::CountingScannerGlueTask<CountingScanner> task(lhs, rhs);
 	return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);
@@ -870,6 +873,9 @@ CountingScanner CountingScanner::Glue(const CountingScanner& lhs, const Counting
 
 AdvancedCountingScanner AdvancedCountingScanner::Glue(const AdvancedCountingScanner& lhs, const AdvancedCountingScanner& rhs, size_t maxSize /* = 0 */)
 {
+    if (lhs.RegexpsCount() + rhs.RegexpsCount() > MAX_RE_COUNT) {
+        return AdvancedCountingScanner();
+    }
 	static constexpr size_t DefMaxSize = 250000;
 	Impl::CountingScannerGlueTask<AdvancedCountingScanner> task(lhs, rhs);
 	return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);

--- a/pire/extra/count.cpp
+++ b/pire/extra/count.cpp
@@ -794,29 +794,29 @@ CountingScanner::CountingScanner(const Fsm& re, const Fsm& sep)
 namespace Impl {
 template <class AdvancedScanner>
 AdvancedScanner MakeAdvancedCountingScanner(const Fsm& re, const Fsm& sep, bool* simple) {
-    Impl::CountingFsm countingFsm{re, sep};
-    if (!countingFsm.Determine()) {
-        throw Error("regexp pattern too complicated");
-    }
-    countingFsm.Minimize();
-    if (simple) {
-        *simple = countingFsm.Simple();
-    }
+	Impl::CountingFsm countingFsm{re, sep};
+	if (!countingFsm.Determine()) {
+		throw Error("regexp pattern too complicated");
+	}
+	countingFsm.Minimize();
+	if (simple) {
+		*simple = countingFsm.Simple();
+	}
 
-    const auto& determined = countingFsm.Determined();
-    const auto& letters = countingFsm.Letters();
+	const auto& determined = countingFsm.Determined();
+	const auto& letters = countingFsm.Letters();
 
-    AdvancedScanner scanner;
-    scanner.Init(determined.Size(), letters, determined.Initial(), 1);
-    for (size_t from = 0; from != determined.Size(); ++from) {
-        for (auto&& lettersEl : letters) {
-            const auto letter = lettersEl.first;
-            const auto& tos = determined.Destinations(from, letter);
-            Y_ASSERT(tos.size() == 1);
-            scanner.SetJump(from, letter, *tos.begin(), scanner.RemapAction(countingFsm.Output(from, letter)));
-        }
-    }
-    return scanner;
+	AdvancedScanner scanner;
+	scanner.Init(determined.Size(), letters, determined.Initial(), 1);
+	for (size_t from = 0; from != determined.Size(); ++from) {
+		for (auto&& lettersEl : letters) {
+			const auto letter = lettersEl.first;
+			const auto& tos = determined.Destinations(from, letter);
+			Y_ASSERT(tos.size() == 1);
+			scanner.SetJump(from, letter, *tos.begin(), scanner.RemapAction(countingFsm.Output(from, letter)));
+		}
+	}
+	return scanner;
 }
 }  // namespace Impl
 
@@ -826,7 +826,7 @@ AdvancedCountingScanner::AdvancedCountingScanner(const Fsm& re, const Fsm& sep, 
 }
 
 NoGlueLimitCountingScanner::NoGlueLimitCountingScanner(const Fsm& re, const Fsm& sep, bool* simple)
-    : NoGlueLimitCountingScanner(Impl::MakeAdvancedCountingScanner<NoGlueLimitCountingScanner>(re, sep, simple))
+	: NoGlueLimitCountingScanner(Impl::MakeAdvancedCountingScanner<NoGlueLimitCountingScanner>(re, sep, simple))
 {
 }
 
@@ -875,87 +875,71 @@ protected:
 
 class NoGlueLimitCountingScannerGlueTask : public CountingScannerGlueTask<NoGlueLimitCountingScanner> {
 public:
-    using ActionIndex = NoGlueLimitCountingScanner::ActionIndex;
-    struct TGlueAction {
-        TVector<ActionIndex> resets;
-        TVector<ActionIndex> increments;
-        bool operator<(const TGlueAction& rhs) const {
-            return std::tie(increments, resets) < std::tie(rhs.increments, rhs.resets);
-        }
-    };
-    using TGlueMap = TMap<TGlueAction, ActionIndex>;
+	using ActionIndex = NoGlueLimitCountingScanner::ActionIndex;
+	struct TGlueAction {
+		TVector<ActionIndex> resets;
+		TVector<ActionIndex> increments;
+		bool operator<(const TGlueAction& rhs) const {
+			return std::tie(increments, resets) < std::tie(rhs.increments, rhs.resets);
+		}
+	};
+	using TGlueMap = TMap<TGlueAction, ActionIndex>;
 
-    NoGlueLimitCountingScannerGlueTask(const NoGlueLimitCountingScanner& lhs, const NoGlueLimitCountingScanner& rhs)
-            : CountingScannerGlueTask(lhs, rhs) {
-    }
+	NoGlueLimitCountingScannerGlueTask(const NoGlueLimitCountingScanner& lhs, const NoGlueLimitCountingScanner& rhs)
+		: CountingScannerGlueTask(lhs, rhs)
+	{
+	}
 
-    void Connect(size_t from, size_t to, Char letter)
-    {
-        TGlueAction glue_action;
-        AppendAction(this->Lhs(), Action(this->Lhs(), States[from].first, letter), 0, &glue_action);
-        AppendAction(this->Rhs(), Action(this->Rhs(), States[from].second, letter), this->Lhs().RegexpsCount(), &glue_action);
-        assert(std::is_sorted(glue_action.increments.begin(), glue_action.increments.end()) &&
-               std::is_sorted(glue_action.resets.begin(), glue_action.resets.end()));
+	void Connect(size_t from, size_t to, Char letter)
+	{
+		TGlueAction glue_action;
+		this->Lhs().GetActions(Action(this->Lhs(), States[from].first, letter), 0,
+							   std::back_inserter(glue_action.resets), std::back_inserter(glue_action.increments));
+		this->Rhs().GetActions(Action(this->Rhs(), States[from].second, letter), this->Lhs().RegexpsCount(),
+							   std::back_inserter(glue_action.resets), std::back_inserter(glue_action.increments));
+		Y_ASSERT(
+			std::is_sorted(glue_action.increments.begin(), glue_action.increments.end()) &&
+			std::is_sorted(glue_action.resets.begin(), glue_action.resets.end())
+		);
 
-        if (glue_action.increments.empty() && glue_action.resets.empty()) {
-            this->Sc().SetJump(from, letter, to, 0);
-            return;
-        }
+		if (glue_action.increments.empty() && glue_action.resets.empty()) {
+			this->Sc().SetJump(from, letter, to, 0);
+			return;
+		}
 
-        auto action_iter = glue_map_.find(glue_action);
-        if (action_iter == glue_map_.end()) {
-            glue_map_[glue_action] = glue_actions_.size();
-            for (const auto& ids : {glue_action.resets, glue_action.increments}) {
-                glue_actions_.push_back(ids.size());
-                std::copy(ids.begin(), ids.end(), std::back_inserter(glue_actions_));
-            }
-        }
+		auto action_iter = glue_map_.find(glue_action);
+		if (action_iter == glue_map_.end()) {
+			glue_map_[glue_action] = glue_actions_.size();
+			for (const auto& ids : {glue_action.resets, glue_action.increments}) {
+				glue_actions_.push_back(ids.size());
+				std::copy(ids.begin(), ids.end(), std::back_inserter(glue_actions_));
+			}
+		}
 
-        this->Sc().SetJump(from, letter, to, glue_map_[glue_action]);
-    }
+		this->Sc().SetJump(from, letter, to, glue_map_[glue_action]);
+	}
 
-    // Return type is same as in parent class
-    // TODO: Maybe return by value to use move semantic?
-    const NoGlueLimitCountingScanner& Success()
-    {
-        glue_actions_[0] = glue_actions_.size();
-        Sc().AcceptActions(glue_actions_);
-        return Sc();
-    }
+	// Return type is same as in parent class
+	// TODO: Maybe return by value to use move semantic?
+	const NoGlueLimitCountingScanner& Success()
+	{
+		glue_actions_[0] = glue_actions_.size();
+		Sc().AcceptActions(glue_actions_);
+		return Sc();
+	}
+
 private:
-    TGlueMap glue_map_;
-    TVector<ActionIndex> glue_actions_ = {1};
-
-    static void AppendAction(const NoGlueLimitCountingScanner& sc, TAction a, ActionIndex id_shift, TGlueAction* glue_action) {
-        if (!a) {
-            return;
-        }
-        if (!sc.Actions) {
-            if (a & NoGlueLimitCountingScanner::ResetAction) {
-                glue_action->resets.push_back(id_shift);
-            }
-            if (a & NoGlueLimitCountingScanner::IncrementAction) {
-                glue_action->increments.push_back(id_shift);
-            }
-            return;
-        }
-        auto action = sc.Actions + a;
-        for (auto reset_count = *action++; reset_count--;) {
-            glue_action->resets.push_back(*action++ + id_shift);
-        }
-        for(auto inc_count = *action++; inc_count--;) {
-            glue_action->increments.push_back(*action++ + id_shift);
-        }
-    }
+	TGlueMap glue_map_;
+	TVector<ActionIndex> glue_actions_ = {1};
 };
 
 }
 	
 CountingScanner CountingScanner::Glue(const CountingScanner& lhs, const CountingScanner& rhs, size_t maxSize /* = 0 */)
 {
-    if (lhs.RegexpsCount() + rhs.RegexpsCount() > MAX_RE_COUNT) {
-        return CountingScanner();
-    }
+	if (lhs.RegexpsCount() + rhs.RegexpsCount() > MAX_RE_COUNT) {
+		return CountingScanner();
+	}
 	static constexpr size_t DefMaxSize = 250000;
 	Impl::CountingScannerGlueTask<CountingScanner> task(lhs, rhs);
 	return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);
@@ -963,9 +947,9 @@ CountingScanner CountingScanner::Glue(const CountingScanner& lhs, const Counting
 
 AdvancedCountingScanner AdvancedCountingScanner::Glue(const AdvancedCountingScanner& lhs, const AdvancedCountingScanner& rhs, size_t maxSize /* = 0 */)
 {
-    if (lhs.RegexpsCount() + rhs.RegexpsCount() > MAX_RE_COUNT) {
-        return AdvancedCountingScanner();
-    }
+	if (lhs.RegexpsCount() + rhs.RegexpsCount() > MAX_RE_COUNT) {
+		return AdvancedCountingScanner();
+	}
 	static constexpr size_t DefMaxSize = 250000;
 	Impl::CountingScannerGlueTask<AdvancedCountingScanner> task(lhs, rhs);
 	return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);
@@ -973,9 +957,51 @@ AdvancedCountingScanner AdvancedCountingScanner::Glue(const AdvancedCountingScan
 
 NoGlueLimitCountingScanner NoGlueLimitCountingScanner::Glue(const NoGlueLimitCountingScanner& lhs, const NoGlueLimitCountingScanner& rhs, size_t maxSize /* = 0 */)
 {
-    static constexpr size_t DefMaxSize = 250000;
-    Impl::NoGlueLimitCountingScannerGlueTask task(lhs, rhs);
-    return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);
+	static constexpr size_t DefMaxSize = 250000;
+	Impl::NoGlueLimitCountingScannerGlueTask task(lhs, rhs);
+	return Impl::Determine(task, maxSize ? maxSize : DefMaxSize);
+}
+
+// Should Save(), Load() and Mmap() functions return stream/pointer in aligned state?
+// Now they don't because tests don't require it.
+void NoGlueLimitCountingScanner::Save(yostream *s) const {
+	LoadedScanner::Save(s);
+	if (Actions) {
+		SavePodArray(s, Actions, *Actions);
+	} else {
+		const ActionIndex zeroSize = 0;
+		SavePodType(s, zeroSize);
+	}
+}
+
+void NoGlueLimitCountingScanner::Load(yistream *s) {
+	LoadedScanner::Load(s);
+	ActionIndex actionsSize;
+	LoadPodType(s, actionsSize);
+
+	if (actionsSize == 0) {
+		ActionsBuffer.reset();
+		Actions = nullptr;
+	} else {
+		ActionsBuffer = TActionsBuffer(new ActionIndex[actionsSize]);
+		ActionsBuffer[0] = actionsSize;
+		LoadPodArray(s, &ActionsBuffer[1], actionsSize - 1);
+		Actions = ActionsBuffer.get();
+	}
+}
+
+const void *NoGlueLimitCountingScanner::Mmap(const void *ptr, size_t size) {
+	NoGlueLimitCountingScanner scanner;
+	auto p = static_cast<const size_t*> (scanner.LoadedScanner::Mmap(ptr, size));
+	scanner.Actions = reinterpret_cast<const ActionIndex*>(p);
+	if (*scanner.Actions == 0) {
+		scanner.Actions = nullptr;
+		Impl::AdvancePtr(p, size, sizeof(ActionIndex));
+	} else {
+		Impl::AdvancePtr(p, size, *scanner.Actions * sizeof(ActionIndex));
+	}
+	Swap(scanner);
+	return (const void*) p;
 }
 
 }

--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -160,7 +160,7 @@ public:
 	PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
 	void TakeAction(State& s, Action a) const
 	{
-		static_cast<const DerivedScanner*>(this)->template TakeActionImpl<OPTIMAL_RE_COUNT>(s, a);
+		static_cast<const DerivedScanner*>(this)->template TakeActionImpl<MAX_RE_COUNT>(s, a);
 	}
 
 	bool CanStop(const State&) const { return false; }

--- a/pire/extra/count.h
+++ b/pire/extra/count.h
@@ -36,6 +36,11 @@ namespace Impl {
 
 	template<class T>
 	class CountingScannerGlueTask;
+
+	class NoGlueLimitCountingScannerGlueTask;
+
+    template <class AdvancedScanner>
+    AdvancedScanner MakeAdvancedCountingScanner(const Fsm& re, const Fsm& sep, bool* simple);
 };
 
 template<size_t I>
@@ -297,6 +302,217 @@ private:
 
 	friend class Impl::ScannerGlueCommon<AdvancedCountingScanner>;
 	friend class Impl::CountingScannerGlueTask<AdvancedCountingScanner>;
+    friend AdvancedCountingScanner Impl::MakeAdvancedCountingScanner<AdvancedCountingScanner>(const Fsm&, const Fsm&, bool*);
+
+};
+
+class NoGlueLimitCountingScanner : public BaseCountingScanner<NoGlueLimitCountingScanner> {
+public:
+    using ActionIndex = ui32;
+    using TActionsBuffer = std::unique_ptr<ActionIndex[]>;
+
+    class State {
+    public:
+        size_t Result(int i) const { return ymax(m_current[i], m_total[i]); }
+
+    private:
+        InternalState m_state;
+        TVector<ui32> m_current;
+        TVector<ui32> m_total;
+
+        friend class NoGlueLimitCountingScanner;
+
+#ifdef PIRE_DEBUG
+        yostream& operator << (yostream& s, const State& state)
+		{
+			s << state.m_state << " ( ";
+			for (size_t i = 0; i < state.m_current.size(); ++i)
+				s << state.m_current[i] << '/' << state.m_total[i] << ' ';
+			return s << ')';
+		}
+#endif
+    };
+
+private:
+    TActionsBuffer ActionsBuffer;
+    const ActionIndex* Actions = nullptr;
+
+public:
+    NoGlueLimitCountingScanner() = default;
+    NoGlueLimitCountingScanner(const Fsm& re, const Fsm& sep, bool* simple = nullptr);
+    NoGlueLimitCountingScanner(const NoGlueLimitCountingScanner& rhs) : BaseCountingScanner(rhs) {
+        if (rhs.ActionsBuffer) {
+            assert(rhs.Actions);
+            ActionsBuffer = TActionsBuffer(new ActionIndex [*rhs.Actions]);
+            memcpy(ActionsBuffer.get(), rhs.ActionsBuffer.get(), *rhs.Actions * sizeof(ActionIndex));
+            Actions = ActionsBuffer.get();
+        } else {
+            Actions = rhs.Actions;
+        }
+    }
+
+    NoGlueLimitCountingScanner(NoGlueLimitCountingScanner&& other) : BaseCountingScanner() {
+        Swap(other);
+    }
+
+    NoGlueLimitCountingScanner& operator=(NoGlueLimitCountingScanner rhs) {
+        Swap(rhs);
+        return *this;
+    }
+
+    void Swap(NoGlueLimitCountingScanner& s) {
+        LoadedScanner::Swap(s);
+        DoSwap(ActionsBuffer, s.ActionsBuffer);
+        DoSwap(Actions, s.Actions);
+    }
+
+    void Initialize(State& state) const
+    {
+        state.m_state = m.initial;
+        state.m_current.assign(RegexpsCount(), 0);
+        state.m_total.assign(RegexpsCount(), 0);
+    }
+
+
+    ////////////////////////////////////////////////////////////
+    // Copy-past from BaseCountingScanner because of changed State type
+    // Alternative is to make State template parameter in all these functions in BaseCountingScanner
+    bool CanStop(const State&) const { return false; }
+
+    Action NextTranslated(State& s, Char c) const
+    {
+        Transition x = reinterpret_cast<const Transition*>(s.m_state)[c];
+        s.m_state += SignExtend(x.shift);
+        return x.action;
+    }
+
+    Action Next(State& s, Char c) const
+    {
+        return NextTranslated(s, Translate(c));
+    }
+
+    Action Next(const State& current, State& n, Char c) const
+    {
+        n = current;
+        return Next(n, c);
+    }
+    using BaseCountingScanner::Next;
+
+    bool Final(const State& /*state*/) const { return false; }
+
+    bool Dead(const State&) const { return false; }
+
+    size_t StateIndex(const State& s) const { return StateIdx(s.m_state); }
+
+    PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+    void TakeAction(State& s, Action a) const
+    {
+        TakeActionImpl<MAX_RE_COUNT>(s, a);
+    }
+    // End of copy-past
+    ////////////////////////////////////////////////////////////////////////
+
+
+    template <size_t>
+    PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+    void TakeActionImpl(State& s, Action a) const
+    {
+        if (!a) {
+            return;
+        }
+        // Note: it's important to perform resets before increments,
+        // as it's possible for one repetition group to stop and another begin at the same symbol
+        if (Actions) {
+            auto action = Actions + a;
+            for (auto reset_count = *action++; reset_count--;) {
+                Reset(s, *action++);
+            }
+            for(auto inc_count = *action++; inc_count--;) {
+                Increment(s, *action++);
+            }
+        } else {
+            Y_ASSERT(RegexpsCount() == 1);
+            if (a & ResetAction) {
+                Reset(s, 0);
+            }
+            if (a & IncrementAction) {
+                Increment(s, 0);
+            }
+        }
+    }
+
+    void Save(yostream* s) const {
+        LoadedScanner::Save(s);
+        if (Actions) {
+            SavePodArray(s, Actions, *Actions);
+        } else {
+            const ActionIndex zeroSize = 0;
+            SavePodType(s, zeroSize);
+        }
+    }
+
+    void Load(yistream* s) {
+        LoadedScanner::Load(s);
+        ActionIndex actionsSize;
+        LoadPodType(s, actionsSize);
+
+        if (actionsSize == 0) {
+            ActionsBuffer.reset();
+            Actions = nullptr;
+        } else {
+            ActionsBuffer = TActionsBuffer(new ActionIndex[actionsSize]);
+            ActionsBuffer[0] = actionsSize;
+            LoadPodArray(s, &ActionsBuffer[1], actionsSize - 1);
+            Actions = ActionsBuffer.get();
+        }
+    }
+
+    const void* Mmap(const void* ptr, size_t size) {
+        NoGlueLimitCountingScanner scanner;
+        auto p = static_cast<const size_t*> (scanner.LoadedScanner::Mmap(ptr, size));
+        scanner.Actions = reinterpret_cast<const ActionIndex*>(p);
+        if (*scanner.Actions == 0) {
+            scanner.Actions = nullptr;
+            Impl::AdvancePtr(p, size, sizeof(ActionIndex));
+        } else {
+            Impl::AdvancePtr(p, size, *scanner.Actions * sizeof(ActionIndex));
+        }
+        Swap(scanner);
+        return (const void*) p;
+    }
+
+    static NoGlueLimitCountingScanner Glue(const NoGlueLimitCountingScanner& a, const NoGlueLimitCountingScanner& b, size_t maxSize = 0);
+
+private:
+    Action RemapAction(Action action)
+    {
+        return action;
+    }
+
+    void AcceptActions(const TVector<ActionIndex>& actions) {
+        Y_ASSERT(!Actions);
+        Y_ASSERT(actions[0] == actions.size());
+
+        ActionsBuffer = TActionsBuffer(new ActionIndex[actions.size()]);
+        memcpy(ActionsBuffer.get(), actions.data(), actions.size() * sizeof(ActionIndex));
+        Actions = ActionsBuffer.get();
+    }
+
+    PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+    static void Reset(State& state, ActionIndex regexp_id) {
+        state.m_current[regexp_id] = 0;
+    }
+
+    PIRE_FORCED_INLINE PIRE_HOT_FUNCTION
+    static void Increment(State& state, ActionIndex regexp_id) {
+        ++state.m_current[regexp_id];
+        state.m_total[regexp_id] = ymax(state.m_total[regexp_id], state.m_current[regexp_id]);
+    }
+
+    friend class Impl::ScannerGlueCommon<NoGlueLimitCountingScanner>;
+    friend class Impl::CountingScannerGlueTask<NoGlueLimitCountingScanner>;
+    friend class Impl::NoGlueLimitCountingScannerGlueTask;
+    friend NoGlueLimitCountingScanner Impl::MakeAdvancedCountingScanner<NoGlueLimitCountingScanner>(const Fsm&, const Fsm&, bool*);
 };
 
 }

--- a/pire/fsm.h
+++ b/pire/fsm.h
@@ -250,7 +250,7 @@ namespace Pire {
 	inline void BuildScanner(const Fsm& fsm, Scanner& r)
 	{
 		TSet<size_t> dead;
-		if (Scanner::DeadFlag)
+		if (Scanner::DeadFlag != 0)
 			dead = fsm.DeadStates();
 
 		for (size_t state = 0; state < fsm.Size(); ++state)

--- a/pire/scanners/loaded.h
+++ b/pire/scanners/loaded.h
@@ -101,6 +101,13 @@ protected:
 	}
 
 	LoadedScanner& operator = (const LoadedScanner& s) { LoadedScanner(s).Swap(*this); return *this; }
+	LoadedScanner (LoadedScanner&& other) : LoadedScanner() {
+	    Swap(other);
+	}
+	LoadedScanner& operator=(LoadedScanner&& other) {
+	    Swap(other);
+        return *this;
+	}
 
 public:
 	size_t Size() const { return m.statesCount; }

--- a/pire/scanners/loaded.h
+++ b/pire/scanners/loaded.h
@@ -102,11 +102,11 @@ protected:
 
 	LoadedScanner& operator = (const LoadedScanner& s) { LoadedScanner(s).Swap(*this); return *this; }
 	LoadedScanner (LoadedScanner&& other) : LoadedScanner() {
-	    Swap(other);
+		Swap(other);
 	}
 	LoadedScanner& operator=(LoadedScanner&& other) {
-	    Swap(other);
-        return *this;
+		Swap(other);
+		return *this;
 	}
 
 public:

--- a/tests/count_ut.cpp
+++ b/tests/count_ut.cpp
@@ -169,9 +169,9 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 		const auto& enc = Pire::Encodings::Latin1();
 		char text[] = "wwwsswwwsssswwws";
 		UNIT_ASSERT_EQUAL(CountOne<Pire::AdvancedCountingScanner>("www", ".{1,6}", text, sizeof(text), enc), size_t(3));
-        UNIT_ASSERT_EQUAL(CountOne<Pire::NoGlueLimitCountingScanner>("www", ".{1,6}", text, sizeof(text), enc), size_t(3));
+		UNIT_ASSERT_EQUAL(CountOne<Pire::NoGlueLimitCountingScanner>("www", ".{1,6}", text, sizeof(text), enc), size_t(3));
 		UNIT_ASSERT_EQUAL(CountOne<Pire::AdvancedCountingScanner>("www.{1,6}", "", text, sizeof(text), enc), size_t(3));
-        UNIT_ASSERT_EQUAL(CountOne<Pire::NoGlueLimitCountingScanner>("www.{1,6}", "", text, sizeof(text), enc), size_t(3));
+		UNIT_ASSERT_EQUAL(CountOne<Pire::NoGlueLimitCountingScanner>("www.{1,6}", "", text, sizeof(text), enc), size_t(3));
 	}
 
 	SIMPLE_UNIT_TEST(CountRepeating)
@@ -201,41 +201,41 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 
 	template <class Scanner>
 	void CountManyGluesOne(size_t maxRegexps) {
-        const auto& encoding = Pire::Encodings::Utf8();
-        auto text = "abcdbaa aa";
-	    TVector<ypair<std::string, std::string>> tasks = {
-            {"a", ".*"},
-            {"b", ".*"},
-            {"c", ".*"},
-            {"ba", ".*"},
-            {"ab",".*"},
-	    };
-	    TVector<size_t> answers = { 5, 2, 1, 1, 1};
-	    Scanner scanner;
-	    size_t regexpsCount = 0;
-	    for (; regexpsCount < maxRegexps; ++regexpsCount) {
-	        const auto& task = tasks[regexpsCount % tasks.size()];
-            const auto regexpFsm = MkFsm(task.first.c_str(), encoding);
-            const auto separatorFsm = MkFsm(task.second.c_str(), encoding);
-	        Scanner next_scanner(regexpFsm, separatorFsm);
-	        auto glue = Scanner::Glue(scanner, next_scanner);
-	        if (glue.Empty()) {
-                break;
-	        }
-	        scanner = std::move(glue);
-	    }
-	    auto state = Run(scanner, text);
-	    for (size_t i = 0; i < regexpsCount; ++i) {
-	        UNIT_ASSERT_EQUAL(state.Result(i), answers[i % answers.size()]);
-	    }
+		const auto& encoding = Pire::Encodings::Utf8();
+		auto text = "abcdbaa aa";
+		TVector<ypair<std::string, std::string>> tasks = {
+			{"a", ".*"},
+			{"b", ".*"},
+			{"c", ".*"},
+			{"ba", ".*"},
+			{"ab",".*"},
+		};
+		TVector<size_t> answers = { 5, 2, 1, 1, 1};
+		Scanner scanner;
+		size_t regexpsCount = 0;
+		for (; regexpsCount < maxRegexps; ++regexpsCount) {
+			const auto& task = tasks[regexpsCount % tasks.size()];
+			const auto regexpFsm = MkFsm(task.first.c_str(), encoding);
+			const auto separatorFsm = MkFsm(task.second.c_str(), encoding);
+			Scanner next_scanner(regexpFsm, separatorFsm);
+			auto glue = Scanner::Glue(scanner, next_scanner);
+			if (glue.Empty()) {
+				break;
+			}
+			scanner = std::move(glue);
+		}
+		auto state = Run(scanner, text);
+		for (size_t i = 0; i < regexpsCount; ++i) {
+			UNIT_ASSERT_EQUAL(state.Result(i), answers[i % answers.size()]);
+		}
 	}
 
 	SIMPLE_UNIT_TEST(CountManyGlues)
-    {
-	    CountManyGluesOne<Pire::CountingScanner>(20);
-	    CountManyGluesOne<Pire::AdvancedCountingScanner>(20);
-	    CountManyGluesOne<Pire::NoGlueLimitCountingScanner>(50);
-    }
+	{
+		CountManyGluesOne<Pire::CountingScanner>(20);
+		CountManyGluesOne<Pire::AdvancedCountingScanner>(20);
+		CountManyGluesOne<Pire::NoGlueLimitCountingScanner>(50);
+	}
 
 	template<class Scanner>
 	void CountBoundariesOne()

--- a/tests/count_ut.cpp
+++ b/tests/count_ut.cpp
@@ -77,6 +77,8 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 		auto countingResult = Run(Pire::CountingScanner{regexpFsm, separatorFsm}, text, len).Result(0);
 		auto newResult = Run(Pire::AdvancedCountingScanner{regexpFsm, separatorFsm}, text, len).Result(0);
 		UNIT_ASSERT_EQUAL(countingResult, newResult);
+		auto noGlueLimitResult = Run(Pire::NoGlueLimitCountingScanner{regexpFsm, separatorFsm}, text, len).Result(0);
+		UNIT_ASSERT_EQUAL(countingResult, noGlueLimitResult);
 		return newResult;
 	}
 
@@ -167,7 +169,9 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 		const auto& enc = Pire::Encodings::Latin1();
 		char text[] = "wwwsswwwsssswwws";
 		UNIT_ASSERT_EQUAL(CountOne<Pire::AdvancedCountingScanner>("www", ".{1,6}", text, sizeof(text), enc), size_t(3));
+        UNIT_ASSERT_EQUAL(CountOne<Pire::NoGlueLimitCountingScanner>("www", ".{1,6}", text, sizeof(text), enc), size_t(3));
 		UNIT_ASSERT_EQUAL(CountOne<Pire::AdvancedCountingScanner>("www.{1,6}", "", text, sizeof(text), enc), size_t(3));
+        UNIT_ASSERT_EQUAL(CountOne<Pire::NoGlueLimitCountingScanner>("www.{1,6}", "", text, sizeof(text), enc), size_t(3));
 	}
 
 	SIMPLE_UNIT_TEST(CountRepeating)
@@ -192,6 +196,7 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 	{
 		CountGlueOne<Pire::CountingScanner>();
 		CountGlueOne<Pire::AdvancedCountingScanner>();
+		CountGlueOne<Pire::NoGlueLimitCountingScanner>();
 	}
 
 	template <class Scanner>
@@ -229,6 +234,7 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
     {
 	    CountManyGluesOne<Pire::CountingScanner>(20);
 	    CountManyGluesOne<Pire::AdvancedCountingScanner>(20);
+	    CountManyGluesOne<Pire::NoGlueLimitCountingScanner>(50);
     }
 
 	template<class Scanner>
@@ -261,6 +267,7 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 	{
 		CountBoundariesOne<Pire::CountingScanner>();
 		CountBoundariesOne<Pire::AdvancedCountingScanner>();
+		CountBoundariesOne<Pire::NoGlueLimitCountingScanner>();
 	}
 
 	template<class Scanner>
@@ -311,6 +318,7 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 	{
 		SerializationOne<Pire::CountingScanner>();
 		SerializationOne<Pire::AdvancedCountingScanner>();
+		SerializationOne<Pire::NoGlueLimitCountingScanner>();
 	}
 
 	template<class Scanner>
@@ -401,6 +409,7 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 	{
 		Serialization_v6_compatibilityOne<Pire::CountingScanner>();
 		Serialization_v6_compatibilityOne<Pire::AdvancedCountingScanner>();
+		//NoGlueLimitCountingScanner is not v6_compatible
 	}
 
 	template<class Scanner>
@@ -442,6 +451,6 @@ SIMPLE_UNIT_TEST_SUITE(TestCount) {
 	{
 		EmptyOne<Pire::CountingScanner>();
 		EmptyOne<Pire::AdvancedCountingScanner>();
+		EmptyOne<Pire::NoGlueLimitCountingScanner>();
 	}
-
 }


### PR DESCRIPTION
1) Added new class NoGlueLimitCountingScanner. It works exactly like AdvancedCountingScanner, but does not have limit on the number of glued regular expressions. New class is added to existing unit tests.

2) Added unit test for gluing many regular expressions. 
Current problem: classes CountingScanner and AdvancedCountingScanner don't check whether the limit on number of expressions is exceeded. Glueing too many expressions just leads to incorrect count results. 
Fix made: now Glue() function returns empty scanner when limit is exceeded. This corresponds to return value when glueing fails due to limit on number of states.
   
3) Some minor fixes and improvements: added move constructors, fixed compiler warnings, etc. 
