### PR TITLE
Added possibility to count with HalfFinalScanner.

### DIFF
--- a/pire/fsm.h
+++ b/pire/fsm.h
@@ -34,6 +34,7 @@ namespace Pire {
 	namespace Impl {
 		class FsmDetermineTask;
 		class FsmMinimizeTask;
+		class HalfFinalDetermineTask;
 	}
 
 	/// A Flying Spaghetti Monster... no, just a Finite State Machine.
@@ -244,6 +245,7 @@ namespace Pire {
 		
 		friend class Impl::FsmDetermineTask;
 		friend class Impl::FsmMinimizeTask;
+		friend class Impl::HalfFinalDetermineTask;
 	};
 
 	template<class Scanner>

--- a/pire/half_final_fsm.cpp
+++ b/pire/half_final_fsm.cpp
@@ -1,8 +1,21 @@
+#include "defs.h"
+#include "determine.h"
 #include "half_final_fsm.h"
 
 namespace Pire {
-	Fsm CreateHalfFinalFsm(Fsm fsm, bool addFinalTransitions, bool count) {
-		bool allowHalfFinals = true;
+	size_t HalfFinalFsm::MaxCountDepth = 10;
+
+	void HalfFinalFsm::MakeScanner() {
+		fsm.Canonize();
+		bool allowHalfFinals = AllowHalfFinals();
+		if (!allowHalfFinals) {
+			MakeHalfFinal();
+			return;
+		}
+		DisconnectFinals(true);
+	}
+
+	bool HalfFinalFsm::AllowHalfFinals() {
 		fsm.Canonize();
 		for (size_t state = 0; state < fsm.Size(); ++state) {
 			if (fsm.IsFinal(state)) {
@@ -13,41 +26,49 @@ namespace Pire {
 							hasFinalTransition = true;
 						}
 					}
-					allowHalfFinals = allowHalfFinals && hasFinalTransition;
+					if (!hasFinalTransition) {
+						return false;
+					}
 				}
 			}
 		}
+		return true;
+	}
+
+	void HalfFinalFsm::MakeHalfFinal() {
 		fsm.Unsparse();
-		if (!allowHalfFinals && !count) {
-			const auto newFinal = fsm.Size();
-			fsm.Resize(newFinal + 1);
-			for (unsigned letter = 0; letter < MaxChar; ++letter) {
-				if (letter != Epsilon) {
-					fsm.Connect(newFinal, newFinal, letter);
-				}
+		const auto newFinal = fsm.Size();
+		fsm.Resize(newFinal + 1);
+		for (unsigned letter = 0; letter < MaxChar; ++letter) {
+			if (letter != Epsilon) {
+				fsm.Connect(newFinal, newFinal, letter);
 			}
-			for (size_t state = 0; state < fsm.Size(); ++state) {
-				bool hasFinalTransitions = false;
-				for (const auto& to : fsm.Destinations(state, EndMark)) {
-					if (fsm.IsFinal(to)) {
-						hasFinalTransitions = true;
-						break;
-					}
-				}
-				if (hasFinalTransitions) {
-					Fsm::StatesSet destinations = fsm.Destinations(state, EndMark);
-					for (const auto& to : destinations) {
-						fsm.Disconnect(state, to, EndMark);
-					}
-					fsm.Connect(state, newFinal, EndMark);
-				}
-			}
-			fsm.ClearFinal();
-			fsm.SetFinal(newFinal, true);
-			fsm.Sparse();
-			return fsm;
 		}
+		for (size_t state = 0; state < fsm.Size(); ++state) {
+			bool hasFinalTransitions = false;
+			for (const auto& to : fsm.Destinations(state, EndMark)) {
+				if (fsm.IsFinal(to)) {
+					hasFinalTransitions = true;
+					break;
+				}
+			}
+			if (hasFinalTransitions) {
+				Fsm::StatesSet destinations = fsm.Destinations(state, EndMark);
+				for (const auto& to : destinations) {
+					fsm.Disconnect(state, to, EndMark);
+				}
+				fsm.Connect(state, newFinal, EndMark);
+			}
+		}
+		fsm.ClearFinal();
+		fsm.SetFinal(newFinal, true);
+		fsm.Sparse();
+	}
+
+	void HalfFinalFsm::DisconnectFinals(bool allowIntersects) {
+		fsm.Unsparse();
 		for (size_t state = 0; state != fsm.Size(); ++state) {
+			fsm.SetTag(state, 0);
 			if (fsm.IsFinal(state)) {
 				for (unsigned letter = 0; letter < MaxChar; ++letter) {
 					Fsm::StatesSet destinations = fsm.Destinations(state, letter);
@@ -55,17 +76,262 @@ namespace Pire {
 						fsm.Disconnect(state, to, letter);
 					}
 				}
-				if (addFinalTransitions) {
+				if (!allowIntersects) {
 					fsm.Connect(state, fsm.Initial());
 				}
 			}
 		}
-		fsm.SetIsDetermined(false);
-		if (count) {
+		if (allowIntersects) {
 			fsm.PrependAnything();
 		}
 		fsm.Sparse();
+		fsm.SetIsDetermined(false);
 		fsm.Canonize();
-		return fsm;
+	}
+
+	void HalfFinalFsm::MakeNonGreedyCounter(bool allowIntersects /* = true */, bool simplify /* = true */) {
+		fsm.Canonize();
+		fsm.PrependAnything();
+		fsm.RemoveDeadEnds();
+		fsm.Canonize();
+		if (!allowIntersects || simplify) {
+			DisconnectFinals(allowIntersects);
+		}
+	}
+
+	void HalfFinalFsm::MakeGreedyCounter(bool simplify /* = true */) {
+		fsm.Canonize();
+		fsm.RemoveDeadEnds();
+		size_t determineFactor = MaxCountDepth;
+		if (simplify) {
+			determineFactor = 1;
+		}
+		Determine(determineFactor);
+		if (simplify) {
+			fsm.Minimize();
+		}
+		fsm.RemoveDeadEnds();
+	}
+
+	namespace Impl {
+
+		class HalfFinalDetermineState {
+		public:
+			HalfFinalDetermineState(const Fsm& fsm, bool initial = false, size_t lastFinalCount = 0)
+				: mFsm(fsm)
+				, ToAdd(0)
+				, LastFinalCount(lastFinalCount)
+			{
+				if (initial) {
+					FinishBuild(1);
+				}
+			}
+
+			HalfFinalDetermineState Next(Char letter, size_t maxCount) const {
+				HalfFinalDetermineState next(mFsm, false, LastFinalCount);
+				for (const auto& state : States) {
+					for (const auto& nextState : mFsm.Destinations(state.State, letter)) {
+						next.AddState(nextState, state.Count, state.ReachedFinal);
+					}
+				}
+				next.FinishBuild(maxCount, States.back().Count);
+				if (letter == EndMark) {
+					next.ToAdd += next.LastFinalCount;
+					next.LastFinalCount = 0;
+					next.States.clear();
+					next.AddState(mFsm.Initial(), 0, false, true);
+					return next;
+				}
+				return next;
+			}
+
+			void CopyData(Fsm& newFsm, size_t index) const {
+				if (ToAdd) {
+					newFsm.SetFinal(index, true);
+					newFsm.SetTag(index, ToAdd);
+				}
+			}
+
+			bool operator<(const HalfFinalDetermineState& otherState) const {
+				if (ToAdd != otherState.ToAdd) {
+					return ToAdd < otherState.ToAdd;
+				}
+				if (LastFinalCount != otherState.LastFinalCount) {
+					return LastFinalCount < otherState.LastFinalCount;
+				}
+				return States < otherState.States;
+			}
+
+			struct StateHolder {
+				size_t State;
+				size_t Count;
+				bool ReachedFinal;
+
+				bool operator<(const StateHolder& other) const {
+					if (State != other.State) {
+						return State < other.State;
+					}
+					if (Count != other.Count) {
+						return Count < other.Count;
+					}
+					return ReachedFinal < other.ReachedFinal;
+				}
+			};
+
+		private:
+			const Fsm& mFsm;
+			TVector<StateHolder> States;
+			size_t ToAdd;
+			size_t LastFinalCount;
+
+			void AddState(size_t state, size_t count, bool reachedFinal, bool force = false) {
+				size_t newLastFinalCount = LastFinalCount;
+				if (mFsm.IsFinal(state) && !reachedFinal) {
+					++count;
+					reachedFinal = true;
+					newLastFinalCount = count;
+				}
+				for (const auto& addedState : States) {
+					if (addedState.State == state) {
+						return;
+					}
+				}
+				if (States.empty() || !mFsm.IsFinal(States.back().State) || force) {
+					States.push_back({state, count, reachedFinal});
+					LastFinalCount = newLastFinalCount;
+				}
+			}
+
+			void FinishBuild(size_t maxCount, size_t lastCount = 0) {
+				if (!States.empty() && mFsm.IsFinal(States.back().State)) {
+					lastCount = States.back().Count;
+				}
+				AddState(mFsm.Initial(), lastCount, false, true);
+				LastFinalCount = std::min(LastFinalCount, maxCount);
+				size_t minCount = States[0].Count;
+				for (auto& state : States) {
+					if (state.Count > maxCount) {
+						state.Count = maxCount;
+					}
+					minCount = std::min(state.Count, minCount);
+				}
+				ToAdd = minCount;
+				for (auto& state : States) {
+					state.Count -= minCount;
+				}
+				LastFinalCount -= minCount;
+			}
+		};
+
+		class HalfFinalDetermineTask {
+		public:
+			typedef HalfFinalDetermineState State;
+			typedef Fsm::LettersTbl LettersTbl;
+			typedef TMap<State, size_t> InvStates;
+
+			HalfFinalDetermineTask(const Fsm& fsm, size_t maxCount)
+				: mFsm(fsm)
+				, MaxCount(maxCount)
+			{
+				size_t oldSize = mFsm.Size();
+				mFsm.Import(fsm);
+				mFsm.Unsparse();
+				for (size_t state = 0; state < mFsm.Size(); ++state) {
+					for (Char letter = 0; letter < MaxChar; ++letter) {
+						Fsm::StatesSet destinations = mFsm.Destinations(state, letter);
+						for (const auto destination : destinations) {
+							size_t newDestination = destination % oldSize;
+							if (letter == EndMark) {
+								newDestination += oldSize;
+							}
+							if (destination != newDestination) {
+								mFsm.Disconnect(state, destination, letter);
+								mFsm.Connect(state, newDestination, letter);
+							}
+						}
+					}
+					if (mFsm.Destinations(state, EndMark).size() == 0) {
+						mFsm.Connect(state, oldSize + mFsm.Initial(), EndMark);
+					}
+				}
+				mFsm.Sparse();
+			}
+
+			const LettersTbl& Letters() const { return mFsm.Letters(); }
+
+			State Initial() const {
+				return State(mFsm, true);
+			}
+
+			State Next(const State& state, Char letter) const {
+				return state.Next(letter, MaxCount);
+			}
+
+			bool IsRequired(const State& /*state*/) const { return true; }
+
+			void AcceptStates(const TVector<State>& newStates) {
+				mNewFsm.Resize(newStates.size());
+				mNewFsm.SetInitial(0);
+				mNewFsm.SetIsDetermined(true);
+				mNewFsm.letters = Letters();
+				mNewFsm.ClearFinal();
+				for (size_t i = 0; i < newStates.size(); i++) {
+					newStates[i].CopyData(mNewFsm, i);
+				}
+			}
+
+			void Connect(size_t from, size_t to, Char letter) {
+				Y_ASSERT(mNewFsm.Destinations(from, letter).size() == 0);
+				mNewFsm.Connect(from, to, letter);
+			}
+
+			typedef bool Result;
+
+			Result Success() { return true; }
+
+			Result Failure() { return false; }
+
+			Fsm& Output() { return mNewFsm; }
+
+			void SetMaxCount(size_t maxCount) {
+				MaxCount = maxCount;
+			}
+
+		private:
+			Fsm mFsm;
+			size_t MaxCount;
+			Fsm mNewFsm;
+		};
+	}
+
+	void HalfFinalFsm::Determine(size_t depth) {
+		static const unsigned MaxSize = 200000;
+
+		Impl::HalfFinalDetermineTask task(fsm, depth);
+		if (!Pire::Impl::Determine(task, MaxSize)) {
+			task.SetMaxCount(1);
+			Pire::Impl::Determine(task, MaxSize);
+		}
+
+		task.Output().Swap(fsm);
+	}
+
+	size_t HalfFinalFsm::GetCount(size_t state) const {
+		if (fsm.IsFinal(state)) {
+			if (fsm.Tag(state)) {
+				return fsm.Tag(state);
+			} else {
+				return 1;
+			}
+		}
+		return 0;
+	}
+
+	size_t HalfFinalFsm::GetTotalCount() const {
+		size_t count = 0;
+		for (size_t state = 0; state < fsm.Size(); ++state) {
+			count += GetCount(state);
+		}
+		return count;
 	}
 }

--- a/pire/half_final_fsm.h
+++ b/pire/half_final_fsm.h
@@ -2,5 +2,47 @@
 #include "defs.h"
 
 namespace Pire {
-	Fsm CreateHalfFinalFsm(Fsm fsm, bool addFinalTransitions = false, bool count = false);
+	class HalfFinalFsm {
+	public:
+		HalfFinalFsm(const Fsm& sourceFsm) : fsm(sourceFsm) {}
+
+		void MakeScanner();
+
+		/// Non greedy counter without allowed intersects works correctly on all regexps
+		/// Non simplified non greedy counter with allowed intersects counts number of positions in string,
+		/// on which ends at least one substring that matches regexp
+		/// Simplified non greedy counter with allowed intersects does not always work correctly,
+		/// but has fewer number of states and more regexps can be glued into single scanner
+		void MakeNonGreedyCounter(bool allowIntersects = true, bool simplify = true);
+
+		// Simplified counter does not work correctly on all regexps, but has less number of states
+		// and allows to glue larger number of scanners into one within the same size limit
+		void MakeGreedyCounter(bool simplify = true);
+
+		const Fsm& GetFsm() const { return fsm; }
+
+		template<class Scanner>
+		Scanner Compile() const;
+
+		size_t GetCount(size_t state) const;
+
+		size_t GetTotalCount() const;
+
+		static size_t MaxCountDepth;
+	private:
+		Fsm fsm;
+
+		bool AllowHalfFinals();
+
+		void MakeHalfFinal();
+
+		void DisconnectFinals(bool allowIntersects);
+
+		void Determine(size_t depth = MaxCountDepth);
+	};
+
+	template<class Scanner>
+	Scanner HalfFinalFsm::Compile() const {
+		auto scanner = Scanner(*this);
+	}
 }


### PR DESCRIPTION
Currently there are 5 different ways to count regexp in text using HalfFinalScanner:

1) Greedy simplified count - counts number of non intersecting greedy regexps matches in text and returns almost the same result as Counting Scanner with .* separator.
2) Greedy non simplified count - same as above, but has larger number of states and returns better result (it still can be incorrect).
3) NonGreedy NonIntersecting count - same as above, but regexps are not taken greedily. Works absolutely correct.
4) NonGreedy Intersecting non simplified count - counts number of positions in string, on which ends at least one substring that matches regexp.
5) NonGreedy Intersecting simplified count - same as previous, but has less number of states and does not always return correct result.

All these types of scanners can be glued with each other and also with normal HalfFinalScanner.