### PR TITLE
Stable serialization of Scanner

### DIFF
--- a/pire/scanners/multi.h
+++ b/pire/scanners/multi.h
@@ -24,6 +24,7 @@
 #ifndef PIRE_SCANNERS_MULTI_H
 #define PIRE_SCANNERS_MULTI_H
 
+#include <cstring>
 #include <string.h>
 #include "common.h"
 #include "../approx_matching.h"
@@ -353,6 +354,7 @@ protected:
 	template<class Eq>
 	void Init(size_t states, const Partition<Char, Eq>& letters, size_t finalStatesCount, size_t startState, size_t regexpsCount = 1)
 	{
+		std::memset(&m, 0, sizeof(m));
 		m.relocationSignature = Relocation::Signature;
 		m.shortcuttingSignature = Shortcutting::Signature;
 		m.statesCount = states;


### PR DESCRIPTION
Compiler adds padding bytes to Scanner::Locals structure. Since values of these bytes may differ from time to time, this makes impossible to compare hashes of serialized regexs, etc.
Memsetting all bytes to zero at the beginning of structure initialization solves the problem.