### PR TITLE
Remove m_finalEnd member from Scanner class

### DIFF
--- a/pire/scanners/half_final.h
+++ b/pire/scanners/half_final.h
@@ -215,13 +215,13 @@ private:
 	void BuildFinals(const HalfFinalFsm& fsm) {
 		Y_ASSERT(Scanner::m_buffer);
 		Y_ASSERT(fsm.GetFsm().Size() == Scanner::Size());
-		Scanner::m_finalEnd = Scanner::m_final;
+		auto m_finalWriter = Scanner::m_final;
 		for (size_t state = 0; state < Scanner::Size(); ++state) {
-			Scanner::m_finalIndex[state] = Scanner::m_finalEnd - Scanner::m_final;
+			Scanner::m_finalIndex[state] = m_finalWriter - Scanner::m_final;
 			for (size_t i = 0; i < fsm.GetCount(state); i++) {
-				*Scanner::m_finalEnd++ = 0;
+				*m_finalWriter++ = 0;
 			}
-			*Scanner::m_finalEnd++ = static_cast<size_t>(-1);
+			*m_finalWriter++ = static_cast<size_t>(-1);
 		}
 	}
 

--- a/pire/scanners/half_final.h
+++ b/pire/scanners/half_final.h
@@ -215,13 +215,13 @@ private:
 	void BuildFinals(const HalfFinalFsm& fsm) {
 		Y_ASSERT(Scanner::m_buffer);
 		Y_ASSERT(fsm.GetFsm().Size() == Scanner::Size());
-		auto m_finalWriter = Scanner::m_final;
+		auto finalWriter = Scanner::m_final;
 		for (size_t state = 0; state < Scanner::Size(); ++state) {
-			Scanner::m_finalIndex[state] = m_finalWriter - Scanner::m_final;
+			Scanner::m_finalIndex[state] = finalWriter - Scanner::m_final;
 			for (size_t i = 0; i < fsm.GetCount(state); i++) {
-				*m_finalWriter++ = 0;
+				*finalWriter++ = 0;
 			}
-			*m_finalWriter++ = static_cast<size_t>(-1);
+			*finalWriter++ = static_cast<size_t>(-1);
 		}
 	}
 

--- a/pire/scanners/multi.h
+++ b/pire/scanners/multi.h
@@ -517,12 +517,12 @@ protected:
 	void FinishBuild()
 	{
 		Y_ASSERT(m_buffer);
-		auto m_finalWriter = m_final;
+		auto finalWriter = m_final;
 		for (size_t state = 0; state != Size(); ++state) {
-			m_finalIndex[state] = m_finalWriter - m_final;
+			m_finalIndex[state] = finalWriter - m_final;
 			if (Header(IndexToState(state)).Common.Flags & FinalFlag)
-				*m_finalWriter++ = 0;
-			*m_finalWriter++ = static_cast<size_t>(-1);
+				*finalWriter++ = 0;
+			*finalWriter++ = static_cast<size_t>(-1);
 		}
 		BuildShortcuts();
 	}
@@ -1029,12 +1029,12 @@ public:
 		this->SetSc(std::unique_ptr<Scanner>(new Scanner));
 		Sc().Init(states.size(), Letters(), finalTableSize, size_t(0), Lhs().RegexpsCount() + Rhs().RegexpsCount());
 
-		auto m_finalWriter = Sc().m_final;
+		auto finalWriter = Sc().m_final;
 		for (size_t state = 0; state != states.size(); ++state) {
-			Sc().m_finalIndex[state] = m_finalWriter - Sc().m_final;
-			m_finalWriter = Shift(Lhs().AcceptedRegexps(states[state].first), 0, m_finalWriter);
-			m_finalWriter = Shift(Rhs().AcceptedRegexps(states[state].second), Lhs().RegexpsCount(), m_finalWriter);
-			*m_finalWriter++ = static_cast<size_t>(-1);
+			Sc().m_finalIndex[state] = finalWriter - Sc().m_final;
+			finalWriter = Shift(Lhs().AcceptedRegexps(states[state].first), 0, finalWriter);
+			finalWriter = Shift(Rhs().AcceptedRegexps(states[state].second), Lhs().RegexpsCount(), finalWriter);
+			*finalWriter++ = static_cast<size_t>(-1);
 			
 			Sc().SetTag(state, ((Lhs().Final(states[state].first) || Rhs().Final(states[state].second)) ? Scanner::FinalFlag : 0)
 				| ((Lhs().Dead(states[state].first) && Rhs().Dead(states[state].second)) ? Scanner::DeadFlag : 0));


### PR DESCRIPTION
There is the `m_finalEnd` member in `Scanner` class that is used only during scanner creation. In some scenarios it is not initialized at all, and this leads to sanitizers' complains.

This commit removes `m_finalEnd` member. Local variables are used instead.