### PR TITLE
Fix -Wdeprecated-copy in half_final.h

### DIFF
--- a/pire/scanners/half_final.h
+++ b/pire/scanners/half_final.h
@@ -61,11 +61,6 @@ public:
 
 		State() : ScannerState(0) {}
 
-		State(const State& otherState)
-			: ScannerState(otherState.ScannerState)
-			, MatchedRegexps(otherState.MatchedRegexps)
-		{}
-
 		State(const typename Scanner::State& otherState) : ScannerState(otherState) {}
 
 		void GetMatchedRegexpsIds() {


### PR DESCRIPTION
Clang 10 warns: definition of implicit copy assignment operator for
'State' is deprecated because it has a user-declared copy constructor
[-Wdeprecated-copy]. This can be fixed by deleting the custom copy
constructor or by defining a custom or defaulted copy assignment.  It
seems that in this case deletion is appropriate, even though the
default copy constructor copies MatchedRegexpsIds.